### PR TITLE
Set mtval for excStoreCapPageFault-s correctly

### DIFF
--- a/src_Core/CPU/CsrFile.bsv
+++ b/src_Core/CPU/CsrFile.bsv
@@ -1118,7 +1118,7 @@ module mkCsrFile #(Data hartid)(CsrFile);
                     excInstAccessFault, excInstPageFault,
                     excLoadAddrMisaligned, excLoadAccessFault,
                     excStoreAddrMisaligned, excStoreAccessFault,
-                    excLoadPageFault, excStorePageFault: return addr;
+                    excLoadPageFault, excStorePageFault, excStoreCapPageFault: return addr;
 
                     default: return 0;
                 endcase);


### PR DESCRIPTION
These were previously defaulting to 0, deeply confusing the kernel.