### PR TITLE
Remove unnecessary bzero in elf_to_hex.

### DIFF
--- a/Tests/elf_to_hex/elf_to_hex.c
+++ b/Tests/elf_to_hex/elf_to_hex.c
@@ -322,7 +322,15 @@ int main (int argc, char *argv [])
     }
 
     // Zero out the memory buffer before loading the ELF file
-    bzero (mem_buf, MAX_MEM_SIZE);
+
+    // XXX this is not necessary because global variables are zero initialised
+    // by default. It is better not to bzero because it takes a while and the
+    // kernel will have to allocate physical memory for lots of pages that could
+    // otherwise be CoW zero pages. This caused issues running regressions in
+    // parallel on a VM where the OOM killer kicked in due to memory ballooning
+    // taking a while to catch up.
+
+    // bzero (mem_buf, MAX_MEM_SIZE);
     // bzero (& (mem_buf [BASE_ADDR_B]), MAX_MEM_SIZE - BASE_ADDR_B);
 
     c_mem_load_elf (argv [1], "_start", "exit", "tohost");


### PR DESCRIPTION
This was causing excessive physical memory usage when running tests in parallel resulting in out-of-memory killer being invoked.