### PR TITLE
Using HPM information from one central struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ builds/RV*/Verilog_RTL
 src_SSITH_P3/Verilog_RTL
 src_SSITH_P3/Verilog_RTL_sim
 **/TagTableStructure.bsv
+**/GenerateHPMVector.bsv
+**/StatCounters.bsv

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libs/cheri-cap-lib"]
 	path = libs/cheri-cap-lib
 	url = https://github.com/CTSRD-CHERI/cheri-cap-lib.git
+[submodule "libs/RISCV_HPM_Events"]
+	path = libs/RISCV_HPM_Events
+	url = https://github.com/CTSRD-CHERI/RISCV_HPM_Events.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libs/cheri-cap-lib"]
 	path = libs/cheri-cap-lib
 	url = https://github.com/CTSRD-CHERI/cheri-cap-lib.git
+[submodule "libs/RISCV_HPM_Events"]
+	path = libs/RISCV_HPM_Events
+	url = git@github.com:CTSRD-CHERI/RISCV_HPM_Events.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "libs/cheri-cap-lib"]
 	path = libs/cheri-cap-lib
 	url = https://github.com/CTSRD-CHERI/cheri-cap-lib.git
-[submodule "libs/RISCV_HPM_Events"]
-	path = libs/RISCV_HPM_Events
-	url = git@github.com:CTSRD-CHERI/RISCV_HPM_Events.git

--- a/Doc/Performance_Monitoring.md
+++ b/Doc/Performance_Monitoring.md
@@ -1,5 +1,7 @@
 # Performance Monitoring Module
 
+**PLEASE NOTE: THIS DOCUMENT IS DEPRECATED AND ONLY EXISTS FOR A PERIOD OF TRANSITION**. For the current mapping, see [here](https://github.com/CTSRD-CHERI/RISCV_HPM_Events/blob/master/counters.yaml).
+
 This overview is based on this [document](https://github.com/CTSRD-CHERI/Flute/blob/CHERI/Doc/Performance_Monitor/Performance_Monitoring.md).
 
 ## Usage

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -58,7 +58,9 @@ BLUESTUFF_DIRS = $(REPO)/libs/BlueStuff:$(REPO)/libs/BlueStuff/AXI:$(REPO)/libs/
 
 TAGCONTROLLER_DIRS = $(REPO)/libs/TagController/TagController:$(REPO)/libs/TagController/TagController/CacheCore
 
-BSC_PATH = $(BLUESTUFF_DIRS):$(ALL_RISCY_DIRS):$(CORE_DIRS):$(TESTBENCH_DIRS):$(TAGCONTROLLER_DIRS):+
+RISCV_HPM_Events_DIRS = $(REPO)/libs/RISCV_HPM_Events
+
+BSC_PATH = $(BLUESTUFF_DIRS):$(ALL_RISCY_DIRS):$(CORE_DIRS):$(TESTBENCH_DIRS):$(TAGCONTROLLER_DIRS):$(RISCV_HPM_Events):+
 
 # ----------------
 # Top-level file and module

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -138,7 +138,24 @@ TagTableStructure.bsv: $(REPO)/libs/TagController/tagsparams.py
 	@echo "INFO: Re-generating CHERI tag controller parameters"
 	$^ -v -c $(CAPSIZE) -s $(TAGS_STRUCT:"%"=%) -a $(TAGS_ALIGN) --data-store-base-addr 0x80000000 -b $@ 0x3fffc000 0xbffff000
 	@echo "INFO: Re-generated CHERI tag controller parameters"
-compile: tagsparams
+#compile: tagsparams
+
+
+.PHONY: generate_hpm_vector
+generate_hpm_vector: GenerateHPMVector.bsv
+GenerateHPMVector.bsv: $(REPO)/libs/RISCV_HPM_Events/parse_counters.py
+	@echo "INFO: Re-generating GenerateHPMVector bluespec file"
+	$^ -f $(REPO)/libs/RISCV_HPM_Events/counters.yaml -b $@
+	@echo "INFO: Re-generated GenerateHPMVector bluespec file"
+
+
+.PHONY: stat_counters
+stat_counters: StatCounters.bsv
+StatCounters.bsv: $(REPO)/libs/RISCV_HPM_Events/parse_counters.py
+	@echo "INFO: Re-generating HPM events struct bluepsec file"
+	$^ -f $(REPO)/libs/RISCV_HPM_Events/counters.yaml -s $@
+	@echo "INFO: Re-generated HPM events struct bluespec file"
+compile: tagsparams #stat_counters generate_hpm_vector
 
 # ================================================================
 

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -58,9 +58,9 @@ BLUESTUFF_DIRS = $(REPO)/libs/BlueStuff:$(REPO)/libs/BlueStuff/AXI:$(REPO)/libs/
 
 TAGCONTROLLER_DIRS = $(REPO)/libs/TagController/TagController:$(REPO)/libs/TagController/TagController/CacheCore
 
-RISCV_HPM_Events_DIRS = $(REPO)/libs/RISCV_HPM_Events
+RISCV_HPM_Events_DIR = $(REPO)/libs/RISCV_HPM_Events
 
-BSC_PATH = $(BLUESTUFF_DIRS):$(ALL_RISCY_DIRS):$(CORE_DIRS):$(TESTBENCH_DIRS):$(TAGCONTROLLER_DIRS):$(RISCV_HPM_Events):+
+BSC_PATH = $(BLUESTUFF_DIRS):$(ALL_RISCY_DIRS):$(CORE_DIRS):$(TESTBENCH_DIRS):$(TAGCONTROLLER_DIRS):$(RISCV_HPM_Events_DIR):+
 
 # ----------------
 # Top-level file and module
@@ -142,17 +142,17 @@ TagTableStructure.bsv: $(REPO)/libs/TagController/tagsparams.py
 
 .PHONY: generate_hpm_vector
 generate_hpm_vector: GenerateHPMVector.bsv
-GenerateHPMVector.bsv: $(REPO)/libs/RISCV_HPM_Events/parse_counters.py
+GenerateHPMVector.bsv: $(RISCV_HPM_Events_DIR)/parse_counters.py
 	@echo "INFO: Re-generating GenerateHPMVector bluespec file"
-	$^ -f $(REPO)/libs/RISCV_HPM_Events/counters.yaml -b $@
+	$^ $(RISCV_HPM_Events_DIR)/counters.yaml -b $@
 	@echo "INFO: Re-generated GenerateHPMVector bluespec file"
 
 
 .PHONY: stat_counters
 stat_counters: StatCounters.bsv
-StatCounters.bsv: $(REPO)/libs/RISCV_HPM_Events/parse_counters.py
+StatCounters.bsv: $(RISCV_HPM_Events_DIR)/parse_counters.py
 	@echo "INFO: Re-generating HPM events struct bluepsec file"
-	$^ -f $(REPO)/libs/RISCV_HPM_Events/counters.yaml -s $@
+	$^ $(RISCV_HPM_Events_DIR)/counters.yaml -s $@
 	@echo "INFO: Re-generated HPM events struct bluespec file"
 compile: tagsparams #stat_counters generate_hpm_vector
 

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -162,11 +162,11 @@ compile: tagsparams #stat_counters generate_hpm_vector
 .PHONY: clean
 clean:
 	rm -r -f  *~  Makefile_*  symbol_table.txt  build_dir/*  obj_dir Verilog_RTL/*
-	rm -f TagTableStructure.bsv
+	rm -f TagTableStructure.bsv StatCounters.bsv GenerateHPMVector.bsv
 
 .PHONY: full_clean
 full_clean: clean
 	rm -r -f  $(SIM_EXE_FILE)*  *.log  *.vcd  *.hex  Logs/
-	rm -f TagTableStructure.bsv .depends.mk
+	rm -f TagTableStructure.bsv GenerateHPMVector.bsv .depends.mk
 
 # ================================================================

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -138,7 +138,6 @@ TagTableStructure.bsv: $(REPO)/libs/TagController/tagsparams.py
 	@echo "INFO: Re-generating CHERI tag controller parameters"
 	$^ -v -c $(CAPSIZE) -s $(TAGS_STRUCT:"%"=%) -a $(TAGS_ALIGN) --data-store-base-addr 0x80000000 -b $@ 0x3fffc000 0xbffff000
 	@echo "INFO: Re-generated CHERI tag controller parameters"
-#compile: tagsparams
 
 
 .PHONY: generate_hpm_vector

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -144,7 +144,7 @@ TagTableStructure.bsv: $(REPO)/libs/TagController/tagsparams.py
 generate_hpm_vector: GenerateHPMVector.bsv
 GenerateHPMVector.bsv: $(RISCV_HPM_Events_DIR)/parse_counters.py
 	@echo "INFO: Re-generating GenerateHPMVector bluespec file"
-	$^ $(RISCV_HPM_Events_DIR)/counters.yaml -b $@
+	$^ $(RISCV_HPM_Events_DIR)/counters.yaml Toooba -b $@
 	@echo "INFO: Re-generated GenerateHPMVector bluespec file"
 
 
@@ -152,7 +152,7 @@ GenerateHPMVector.bsv: $(RISCV_HPM_Events_DIR)/parse_counters.py
 stat_counters: StatCounters.bsv
 StatCounters.bsv: $(RISCV_HPM_Events_DIR)/parse_counters.py
 	@echo "INFO: Re-generating HPM events struct bluepsec file"
-	$^ $(RISCV_HPM_Events_DIR)/counters.yaml -s $@
+	$^ $(RISCV_HPM_Events_DIR)/counters.yaml Toooba -s $@
 	@echo "INFO: Re-generated HPM events struct bluespec file"
 compile: tagsparams #stat_counters generate_hpm_vector
 

--- a/builds/Resources/Include_bluesim.mk
+++ b/builds/Resources/Include_bluesim.mk
@@ -15,7 +15,7 @@ build_dir:
 ifeq (,$(filter clean full_clean,$(MAKECMDGOALS)))
 include .depends.mk
 
-.depends.mk: TagTableStructure.bsv StatCounters.bsv | build_dir
+.depends.mk: TagTableStructure.bsv StatCounters.bsv GenerateHPMVector.bsv | build_dir
 	if ! bluetcl -exec makedepend -elab -sim  $(TMP_DIRS)  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS)  -p $(BSC_PATH) -o $@ $(TOPFILE); then rm -f $@ && false; fi
 endif
 

--- a/builds/Resources/Include_bluesim.mk
+++ b/builds/Resources/Include_bluesim.mk
@@ -15,7 +15,7 @@ build_dir:
 ifeq (,$(filter clean full_clean,$(MAKECMDGOALS)))
 include .depends.mk
 
-.depends.mk: TagTableStructure.bsv | build_dir
+.depends.mk: TagTableStructure.bsv StatCounters.bsv | build_dir
 	if ! bluetcl -exec makedepend -elab -sim  $(TMP_DIRS)  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS)  -p $(BSC_PATH) -o $@ $(TOPFILE); then rm -f $@ && false; fi
 endif
 

--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -103,7 +103,8 @@ import Bypass::*;
 import CHERICap::*;
 import CHERICC_Fat::*;
 import Bag::*;
-import VnD :: *;
+import VnD::*;
+import StatCounters::*;
 
 `ifdef RVFI_DII
 import Toooba_RVFI_DII_Bridge::*;
@@ -209,7 +210,7 @@ interface Core;
 `endif
 
 `ifdef PERFORMANCE_MONITORING
-    method Action events_llc(EventsCache events);
+    method Action events_llc(EventsLL events);
     method Action events_tgc(Vector#(7, Bit#(1)) events);
 `endif
 endinterface
@@ -236,24 +237,24 @@ typedef enum {
    } Core_Run_State
 deriving (Bits, Eq, FShow);
 
-`ifdef PERFORMANCE_MONITORING
-instance BitVectorable #(EventsCore, SizeOf#(SupCnt), EventsCoreElements) provisos (Bits #(EventsCore, m));
-   function Vector#(EventsCoreElements, SupCnt) to_vector(EventsCore e) =
-      reverse(unpack(pack(e)));
-endinstance
-instance BitVectorable #(EventsCoreMem, SizeOf#(HpmRpt), EventsCoreMemElements) provisos (Bits #(EventsCoreMem, m));
-   function Vector#(EventsCoreMemElements, HpmRpt) to_vector(EventsCoreMem e) =
-      reverse(unpack(pack(e)));
-endinstance
-instance BitVectorable #(EventsTransExe, SizeOf#(SupCnt), EventsTransExeElements) provisos (Bits #(EventsTransExe, m));
-   function Vector#(EventsTransExeElements, SupCnt) to_vector(EventsTransExe e) =
-      reverse(unpack(pack(e)));
-endinstance
-instance BitVectorable #(EventsCache, SizeOf#(HpmRpt), EventsCacheElements) provisos (Bits #(EventsCache, m));
-   function Vector#(EventsCacheElements, HpmRpt) to_vector(EventsCache e) =
-      reverse(unpack(pack(e)));
-endinstance
-`endif
+//`ifdef PERFORMANCE_MONITORING
+//instance BitVectorable #(EventsCore, SizeOf#(SupCnt), EventsCoreElements) provisos (Bits #(EventsCore, m));
+//   function Vector#(EventsCoreElements, SupCnt) to_vector(EventsCore e) =
+//      reverse(unpack(pack(e)));
+//endinstance
+//instance BitVectorable #(EventsCoreMem, SizeOf#(HpmRpt), EventsCoreMemElements) provisos (Bits #(EventsCoreMem, m));
+//   function Vector#(EventsCoreMemElements, HpmRpt) to_vector(EventsCoreMem e) =
+//      reverse(unpack(pack(e)));
+//endinstance
+//instance BitVectorable #(EventsTransExe, SizeOf#(SupCnt), EventsTransExeElements) provisos (Bits #(EventsTransExe, m));
+//   function Vector#(EventsTransExeElements, SupCnt) to_vector(EventsTransExe e) =
+//      reverse(unpack(pack(e)));
+//endinstance
+//instance BitVectorable #(EventsCache, SizeOf#(HpmRpt), EventsCacheElements) provisos (Bits #(EventsCache, m));
+//   function Vector#(EventsCacheElements, HpmRpt) to_vector(EventsCache e) =
+//      reverse(unpack(pack(e)));
+//endinstance
+//`endif
 
 (* synthesize *)
 module mkCore#(CoreId coreId)(Core);
@@ -1165,7 +1166,7 @@ module mkCore#(CoreId coreId)(Core);
      // Each cache and TLB pair uses the same struct (EventsCache), but the cache accesses
      // different fields than the TLB, which makes it safe to combine them
 
-     Reg#(EventsCache) events_llc_reg <- mkRegU;
+     Reg#(EventsLL) events_llc_reg <- mkRegU;
      Reg#(Vector#(7, Bit#(1))) events_tgc_reg <- mkRegU;
      rule report_events;
          EventsCore events = unpack(pack(commitStage.events));
@@ -1173,17 +1174,17 @@ module mkCore#(CoreId coreId)(Core);
          hpm_core_events[1] <= events;
      endrule
 
-     Vector #(1, Bit #(Report_Width)) null_evt = replicate (0);
-     Vector #(31, Bit #(Report_Width)) mem_core_evts_vec =  to_large_vector (coreFix.memExeIfc.events);
-     Vector #(31, Bit #(Report_Width)) other_core_evts_vec = to_large_vector (hpm_core_events[0]);
-     Vector #(31, Bit #(Report_Width)) core_evts_vec = unpack(pack(mem_core_evts_vec) | pack(other_core_evts_vec));
-     EventsCache instMem = unpack(pack(iMem.events) | pack(iTlb.events));
-     Vector #(16, Bit #(Report_Width)) imem_evts_vec = to_large_vector (instMem);
-     EventsCache dataMem = unpack(pack(dMem.events) | pack(dTlb.events));
-     Vector #(16, Bit #(Report_Width)) dmem_evts_vec = to_large_vector (dataMem);
-     Vector #(32, Bit #(Report_Width)) tgc_evts_vec = to_large_vector (events_tgc_reg);
-     EventsCache llMem = unpack(pack(events_llc_reg) | pack(l2Tlb.events));
-     Vector #(16, Bit #(Report_Width)) llc_evts_vec = to_large_vector (llMem);
+     //Vector #(1, Bit #(Report_Width)) null_evt = replicate (0);
+     //Vector #(31, Bit #(Report_Width)) mem_core_evts_vec =  to_large_vector (coreFix.memExeIfc.events);
+     //Vector #(31, Bit #(Report_Width)) other_core_evts_vec = to_large_vector (hpm_core_events[0]);
+     //Vector #(31, Bit #(Report_Width)) core_evts_vec = unpack(pack(mem_core_evts_vec) | pack(other_core_evts_vec));
+     //EventsCache instMem = unpack(pack(iMem.events) | pack(iTlb.events));
+     //Vector #(16, Bit #(Report_Width)) imem_evts_vec = to_large_vector (instMem);
+     //EventsCache dataMem = unpack(pack(dMem.events) | pack(dTlb.events));
+     //Vector #(16, Bit #(Report_Width)) dmem_evts_vec = to_large_vector (dataMem);
+     //Vector #(32, Bit #(Report_Width)) tgc_evts_vec = to_large_vector (events_tgc_reg);
+     //EventsCache llMem = unpack(pack(events_llc_reg) | pack(l2Tlb.events));
+     //Vector #(16, Bit #(Report_Width)) llc_evts_vec = to_large_vector (llMem);
 
 `ifdef CONTRACTS_VERIFY
      EventsTransExe transExe = renameStage.events;
@@ -1200,11 +1201,12 @@ module mkCore#(CoreId coreId)(Core);
      Vector #(16, Bit #(Report_Width)) trans_exe_evts_vec = to_large_vector (transExe);
 `endif
 
-     let events = append (null_evt, core_evts_vec);
-     events = append (events, imem_evts_vec);
-     events = append (events, dmem_evts_vec);
-     events = append (events, tgc_evts_vec);
-     events = append (events, llc_evts_vec);
+     //let events = append (null_evt, core_evts_vec);
+     //events = append (events, imem_evts_vec);
+     //events = append (events, dmem_evts_vec);
+     //events = append (events, tgc_evts_vec);
+     //events = append (events, llc_evts_vec);
+     Vector#(112, Bit#(Report_Width)) events = replicate(0);
 `ifdef CONTRACTS_VERIFY
      events = append (events, trans_exe_evts_vec);
 `endif

--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -63,6 +63,8 @@ import Performance::*;
 `ifdef PERFORMANCE_MONITORING
 import PerformanceMonitor::*;
 import BlueUtils::*;
+import StatCounters::*;
+import GenerateHPMVector::*;
 `endif
 import HasSpecBits::*;
 import Exec::*;
@@ -104,8 +106,6 @@ import CHERICap::*;
 import CHERICC_Fat::*;
 import Bag::*;
 import VnD::*;
-import StatCounters::*;
-import GenerateHPMVector::*;
 
 `ifdef RVFI_DII
 import Toooba_RVFI_DII_Bridge::*;
@@ -238,24 +238,6 @@ typedef enum {
    } Core_Run_State
 deriving (Bits, Eq, FShow);
 
-//`ifdef PERFORMANCE_MONITORING
-//instance BitVectorable #(EventsCore, SizeOf#(SupCnt), EventsCoreElements) provisos (Bits #(EventsCore, m));
-//   function Vector#(EventsCoreElements, SupCnt) to_vector(EventsCore e) =
-//      reverse(unpack(pack(e)));
-//endinstance
-//instance BitVectorable #(EventsCoreMem, SizeOf#(HpmRpt), EventsCoreMemElements) provisos (Bits #(EventsCoreMem, m));
-//   function Vector#(EventsCoreMemElements, HpmRpt) to_vector(EventsCoreMem e) =
-//      reverse(unpack(pack(e)));
-//endinstance
-//instance BitVectorable #(EventsTransExe, SizeOf#(SupCnt), EventsTransExeElements) provisos (Bits #(EventsTransExe, m));
-//   function Vector#(EventsTransExeElements, SupCnt) to_vector(EventsTransExe e) =
-//      reverse(unpack(pack(e)));
-//endinstance
-//instance BitVectorable #(EventsCache, SizeOf#(HpmRpt), EventsCacheElements) provisos (Bits #(EventsCache, m));
-//   function Vector#(EventsCacheElements, HpmRpt) to_vector(EventsCache e) =
-//      reverse(unpack(pack(e)));
-//endinstance
-//`endif
 
 (* synthesize *)
 module mkCore#(CoreId coreId)(Core);
@@ -1175,47 +1157,33 @@ module mkCore#(CoreId coreId)(Core);
          hpm_core_events[1] <= events;
      endrule
 
-     //Vector #(1, Bit #(Report_Width)) null_evt = replicate (0);
-     //Vector #(31, Bit #(Report_Width)) mem_core_evts_vec =  to_large_vector (coreFix.memExeIfc.events);
-     //Vector #(31, Bit #(Report_Width)) other_core_evts_vec = to_large_vector (hpm_core_events[0]);
-     //Vector #(31, Bit #(Report_Width)) core_evts_vec = unpack(pack(mem_core_evts_vec) | pack(other_core_evts_vec));
      EventsCore core_evts = unpack(pack(coreFix.memExeIfc.events) | pack(hpm_core_events[0]));
-     //EventsCache instMem = unpack(pack(iMem.events) | pack(iTlb.events));
      EventsL1I imem_evts = unpack(pack(iMem.events) | pack(iTlb.events));
-     //Vector #(16, Bit #(Report_Width)) imem_evts_vec = to_large_vector (instMem);
-     //EventsCache dataMem = unpack(pack(dMem.events) | pack(dTlb.events));
      EventsL1D dmem_evts = unpack(pack(dMem.events) | pack(dTlb.events));
-     //Vector #(16, Bit #(Report_Width)) dmem_evts_vec = to_large_vector (dataMem);
      EventsCacheCore tgc_evts = events_tgc_reg;
-     //Vector #(32, Bit #(Report_Width)) tgc_evts_vec = to_large_vector (events_tgc_reg);
-     //EventsCache llMem = unpack(pack(events_llc_reg) | pack(l2Tlb.events));
      EventsLL llmem_evts = unpack(pack(events_llc_reg) | pack(l2Tlb.events));
-     //Vector #(16, Bit #(Report_Width)) llc_evts_vec = to_large_vector (llMem);
+
+     let ev_struct = HPMEvents{mab_EventsCore: tagged Valid core_evts, mab_EventsL1I: tagged Valid imem_evts,
+                               mab_EventsL1D: tagged Valid dmem_evts, mab_EventsLL: tagged Valid llmem_evts,
+                               mab_EventsCacheCore: tagged Valid tgc_evts};
 
 `ifdef CONTRACTS_VERIFY
-     EventsTransExe transExe = renameStage.events;
+     EventsTransExe texe_evts = renameStage.events;
      SupCnt wildJumps = 0;
-     SupCnt wildExceptions = transExe.evt_WILD_EXCEPTION;
+     SupCnt wildExceptions = texe_evts.evt_WILD_EXCEPTION;
      for(Integer i = 0; i < valueof(AluExeNum); i = i+1) begin
           let alu_events = coreFix.aluExeIfc[i].events;
           wildJumps = wildJumps + alu_events.evt_WILD_JUMP;
           wildExceptions = wildExceptions + alu_events.evt_WILD_EXCEPTION;
      end
 
-     transExe.evt_WILD_JUMP = wildJumps;
-     transExe.evt_WILD_EXCEPTION = wildExceptions;
-     Vector #(16, Bit #(Report_Width)) trans_exe_evts_vec = to_large_vector (transExe);
+     texe_evts.evt_WILD_JUMP = wildJumps;
+     texe_evts.evt_WILD_EXCEPTION = wildExceptions;
+     ev_struct = HPMEvents{mab_EventsCore: tagged Valid core_evts, mab_EventsL1I: tagged Valid imem_evts,
+                               mab_EventsL1D: tagged Valid dmem_evts, mab_EventsLL: tagged Valid llmem_evts,
+                               mab_EventsCacheCore: tagged Valid tgc_evts, mab_EventsTransExe: tagged Valid texe_evts};
 `endif
 
-     //let events = append (null_evt, core_evts_vec);
-     //events = append (events, imem_evts_vec);
-     //events = append (events, dmem_evts_vec);
-     //events = append (events, tgc_evts_vec);
-     //events = append (events, llc_evts_vec);
-     //Vector#(109, Bit#(Report_Width)) events = replicate(0);
-     let ev_struct = HPMEvents{mab_EventsCore: tagged Valid core_evts, mab_EventsL1I: tagged Valid imem_evts,
-                               mab_EventsL1D: tagged Valid dmem_evts, mab_EventsLL: tagged Valid llmem_evts,
-                               mab_EventsCacheCore: tagged Valid tgc_evts};
      let events = generateHPMVector(ev_struct);
 `ifdef CONTRACTS_VERIFY
      events = append (events, trans_exe_evts_vec);

--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -211,7 +211,7 @@ interface Core;
 
 `ifdef PERFORMANCE_MONITORING
     method Action events_llc(EventsLL events);
-    method Action events_tgc(Vector#(7, Bit#(1)) events);
+    method Action events_tgc(EventsCacheCore events);
 `endif
 endinterface
 
@@ -1167,7 +1167,7 @@ module mkCore#(CoreId coreId)(Core);
      // different fields than the TLB, which makes it safe to combine them
 
      Reg#(EventsLL) events_llc_reg <- mkRegU;
-     Reg#(Vector#(7, Bit#(1))) events_tgc_reg <- mkRegU;
+     Reg#(EventsCacheCore) events_tgc_reg <- mkRegU;
      rule report_events;
          EventsCore events = unpack(pack(commitStage.events));
          events.evt_REDIRECT = zeroExtend(pack(fetchStage.redirect_evt));

--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -1182,7 +1182,8 @@ module mkCore#(CoreId coreId)(Core);
 
      let ev_struct = HPMEvents{mab_EventsCore: tagged Valid core_evts, mab_EventsL1I: tagged Valid imem_evts,
                                mab_EventsL1D: tagged Valid dmem_evts, mab_EventsLL: tagged Valid llmem_evts,
-                               mab_EventsCacheCore: tagged Valid tgc_evts, mab_EventsTransExe: mab_trans_exe};
+                               mab_EventsCacheCore: tagged Valid tgc_evts, mab_EventsTransExe: mab_trans_exe,
+                               mab_AXI4_Slave_Events: tagged Invalid, mab_AXI4_Master_Events: tagged Invalid};
 
      let events = generateHPMVector(ev_struct);
 

--- a/src_Core/CPU/CsrFile.bsv
+++ b/src_Core/CPU/CsrFile.bsv
@@ -40,6 +40,7 @@
 `include "ProcConfig.bsv"
 import Types::*;
 import ProcTypes::*;
+import StatCounters::*;
 import DefaultValue::*;
 import ConcatReg::*;
 import ConfigReg::*;

--- a/src_Core/CPU/CsrFile.bsv
+++ b/src_Core/CPU/CsrFile.bsv
@@ -40,7 +40,6 @@
 `include "ProcConfig.bsv"
 import Types::*;
 import ProcTypes::*;
-import StatCounters::*;
 import DefaultValue::*;
 import ConcatReg::*;
 import ConfigReg::*;
@@ -61,6 +60,7 @@ import Cur_Cycle  :: *;
 
 `ifdef PERFORMANCE_MONITORING
 import PerformanceMonitor :: *;
+import StatCounters::*;
 `endif
 
 // ================================================================

--- a/src_Core/CPU/Proc.bsv
+++ b/src_Core/CPU/Proc.bsv
@@ -79,6 +79,7 @@ import MMIOAddrs::*;
 import MMIOCore::*;
 import DramCommon::*;
 import Performance::*;
+import StatCounters::*;
 
 // ----------------
 // From Tooba
@@ -178,7 +179,7 @@ module mkProc (Proc_IFC);
    endrule
 
 `ifdef PERFORMANCE_MONITORING
-   Reg#(Vector#(7, Bit#(1))) events_tgc_reg <- mkRegU;
+   Reg#(EventsCacheCore) events_tgc_reg <- mkRegU;
    rule broadcastPerfEvents;
        for(Integer j = 0; j < valueof(CoreNum); j = j+1) begin
            core[j].events_llc(llc.events);

--- a/src_Core/CPU/Proc_IFC.bsv
+++ b/src_Core/CPU/Proc_IFC.bsv
@@ -36,6 +36,7 @@ import Fabric_Defs :: *;
 import SoC_Map :: *;
 import CCTypes :: *;
 import ProcTypes :: *;
+import StatCounters::*;
 
 `ifdef INCLUDE_GDB_CONTROL
 import DM_CPU_Req_Rsp :: *;
@@ -129,7 +130,7 @@ interface Proc_IFC;
 `endif
 
 `ifdef PERFORMANCE_MONITORING
-    method Action events_tgc(Vector#(7, Bit#(1)) events);
+    method Action events_tgc(EventsCacheCore events);
 `endif
 
 endinterface

--- a/src_Core/Core/CoreW.bsv
+++ b/src_Core/Core/CoreW.bsv
@@ -67,6 +67,7 @@ import TagControllerAXI :: *;
 // ----------------
 // From RISCY-ooo
 import ProcTypes    :: *;
+import StatCounters::*;
 
 // ----------------
 // From Toooba
@@ -177,7 +178,7 @@ module mkCoreW #(Reset dm_power_on_reset)
    mkConnection(proc.master0, tagController.slave, reset_by all_harts_reset);
 `ifdef PERFORMANCE_MONITORING
    rule report_tagController_events;
-      Vector#(7, Bit#(1)) evts = tagController.events;
+      EventsCacheCore evts = tagController.events;
       proc.events_tgc(evts);
    endrule
 `endif

--- a/src_Core/RISCY_OOO/coherence/src/CCTypes.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/CCTypes.bsv
@@ -45,25 +45,25 @@ import Connectable::*;
 import GetPut::*;
 import ClientServer::*;
 
-`ifdef PERFORMANCE_MONITORING
-typedef struct {
-   Bit#(8) evt_LD;
-   Bit#(8) evt_LD_MISS;
-   Bit#(8) evt_LD_MISS_LAT;
-   Bit#(8) evt_ST;
-   Bit#(8) evt_ST_MISS;
-   Bit#(8) evt_ST_MISS_LAT; // Unimplemented
-   Bit#(8) evt_AMO;
-   Bit#(8) evt_AMO_MISS;
-   Bit#(8) evt_AMO_MISS_LAT;
-   Bit#(8) evt_TLB;
-   Bit#(8) evt_TLB_MISS;     // Only leaf is stored in TLB thus a full
-   Bit#(8) evt_TLB_MISS_LAT; // walk must happen every miss
-   Bit#(8) evt_TLB_FLUSH;
-   Bit#(8) evt_EVICT;
-} EventsCache deriving (Bits, FShow);
-typedef TDiv#(SizeOf#(EventsCache),8) EventsCacheElements;
-`endif
+//`ifdef PERFORMANCE_MONITORING
+//typedef struct {
+//   Bit#(8) evt_LD;
+//   Bit#(8) evt_LD_MISS;
+//   Bit#(8) evt_LD_MISS_LAT;
+//   Bit#(8) evt_ST;
+//   Bit#(8) evt_ST_MISS;
+//   Bit#(8) evt_ST_MISS_LAT; // Unimplemented
+//   Bit#(8) evt_AMO;
+//   Bit#(8) evt_AMO_MISS;
+//   Bit#(8) evt_AMO_MISS_LAT;
+//   Bit#(8) evt_TLB;
+//   Bit#(8) evt_TLB_MISS;     // Only leaf is stored in TLB thus a full
+//   Bit#(8) evt_TLB_MISS_LAT; // walk must happen every miss
+//   Bit#(8) evt_TLB_FLUSH;
+//   Bit#(8) evt_EVICT;
+//} EventsCache deriving (Bits, FShow);
+//typedef TDiv#(SizeOf#(EventsCache),8) EventsCacheElements;
+//`endif
 
 typedef enum {
     I = 2'd0,

--- a/src_Core/RISCY_OOO/coherence/src/CCTypes.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/CCTypes.bsv
@@ -45,26 +45,6 @@ import Connectable::*;
 import GetPut::*;
 import ClientServer::*;
 
-//`ifdef PERFORMANCE_MONITORING
-//typedef struct {
-//   Bit#(8) evt_LD;
-//   Bit#(8) evt_LD_MISS;
-//   Bit#(8) evt_LD_MISS_LAT;
-//   Bit#(8) evt_ST;
-//   Bit#(8) evt_ST_MISS;
-//   Bit#(8) evt_ST_MISS_LAT; // Unimplemented
-//   Bit#(8) evt_AMO;
-//   Bit#(8) evt_AMO_MISS;
-//   Bit#(8) evt_AMO_MISS_LAT;
-//   Bit#(8) evt_TLB;
-//   Bit#(8) evt_TLB_MISS;     // Only leaf is stored in TLB thus a full
-//   Bit#(8) evt_TLB_MISS_LAT; // walk must happen every miss
-//   Bit#(8) evt_TLB_FLUSH;
-//   Bit#(8) evt_EVICT;
-//} EventsCache deriving (Bits, FShow);
-//typedef TDiv#(SizeOf#(EventsCache),8) EventsCacheElements;
-//`endif
-
 typedef enum {
     I = 2'd0,
     S = 2'd1,

--- a/src_Core/RISCY_OOO/coherence/src/IBank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/IBank.bsv
@@ -61,6 +61,7 @@ import RandomReplace::*;
 import PerformanceMonitor::*;
 import BlueUtils::*;
 `endif
+import StatCounters::*;
 
 export ICRqStuck(..);
 export IPRqStuck(..);
@@ -102,7 +103,7 @@ interface IBank#(
     method Action setPerfStatus(Bool stats);
     method Data getPerfData(L1IPerfType t);
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsL1I events;
 `endif
 endinterface
 
@@ -193,7 +194,7 @@ module mkIBank#(
     Count#(Data) ldMissLat <- mkCount(0);
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsCache)) perf_events <- mkDRegOR (2, unpack (0));
+    Array #(Reg #(EventsL1I)) perf_events <- mkDRegOR (2, unpack (0));
 `endif
     function Action incrReqCnt;
     action
@@ -203,7 +204,7 @@ module mkIBank#(
         end
 `endif
 `ifdef PERFORMANCE_MONITORING
-        EventsCache events = unpack (0);
+        EventsL1I events = unpack (0);
         events.evt_LD = 1;
         perf_events[0] <= events;
 `endif
@@ -221,7 +222,7 @@ module mkIBank#(
         end
 `endif
 `ifdef PERFORMANCE_MONITORING
-        EventsCache events = unpack (0);
+        EventsL1I events = unpack (0);
         events.evt_LD_MISS_LAT = saturating_truncate(lat);
         events.evt_LD_MISS = 1;
         perf_events[1] <= events;
@@ -838,7 +839,7 @@ module mkIBank#(
         endcase);
     endmethod
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = perf_events[0];
+    method EventsL1I events = perf_events[0];
 `endif
 endmodule
 

--- a/src_Core/RISCY_OOO/coherence/src/IBank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/IBank.bsv
@@ -60,8 +60,8 @@ import RandomReplace::*;
 `ifdef PERFORMANCE_MONITORING
 import PerformanceMonitor::*;
 import BlueUtils::*;
-`endif
 import StatCounters::*;
+`endif
 
 export ICRqStuck(..);
 export IPRqStuck(..);

--- a/src_Core/RISCY_OOO/coherence/src/L1Bank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/L1Bank.bsv
@@ -64,6 +64,7 @@ import RandomReplace::*;
 import PerformanceMonitor::*;
 import BlueUtils::*;
 `endif
+import StatCounters::*;
 
 export L1CRqStuck(..);
 export L1PRqStuck(..);
@@ -108,7 +109,7 @@ interface L1Bank#(
     method Action setPerfStatus(Bool stats);
     method Data getPerfData(L1DPerfType t);
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsL1D events;
 `endif
 endinterface
 
@@ -212,7 +213,7 @@ module mkL1Bank#(
     Count#(Data) amoMissLat <- mkCount(0);
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsCache)) perf_events <- mkDRegOR (2, unpack (0));
+    Array #(Reg #(EventsL1D)) perf_events <- mkDRegOR (2, unpack (0));
 `endif
 function Action incrReqCnt(MemOp op);
 action
@@ -226,7 +227,7 @@ action
     end
 `endif
 `ifdef PERFORMANCE_MONITORING
-    EventsCache events = unpack (0);
+    EventsL1D events = unpack (0);
     case(op)
         Ld: events.evt_LD = 1;
         St: events.evt_ST = 1;
@@ -260,7 +261,7 @@ action
     end
 `endif
 `ifdef PERFORMANCE_MONITORING
-    EventsCache events = unpack (0);
+    EventsL1D events = unpack (0);
     case(op)
         Ld: begin
             events.evt_LD_MISS_LAT = saturating_truncate(lat);
@@ -1130,7 +1131,7 @@ endfunction
         endcase);
     endmethod
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = perf_events[0];
+    method EventsL1D events = perf_events[0];
 `endif
 endmodule
 
@@ -1364,8 +1365,8 @@ module mkL1Cache#(
         return fold(\+ , d);
     endmethod
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
-        EventsCache ret = unpack(0);
+    method EventsL1D events;
+        EventsL1D ret = unpack(0);
         for(Integer i = 0; i < valueof(bankNum); i = i+1) begin
             ret = unpack(pack(ret) | pack(banks[i].events));
         end

--- a/src_Core/RISCY_OOO/coherence/src/L1Bank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/L1Bank.bsv
@@ -62,9 +62,9 @@ import LatencyTimer::*;
 import RandomReplace::*;
 `ifdef PERFORMANCE_MONITORING
 import PerformanceMonitor::*;
+import StatCounters::*;
 import BlueUtils::*;
 `endif
-import StatCounters::*;
 
 export L1CRqStuck(..);
 export L1PRqStuck(..);

--- a/src_Core/RISCY_OOO/coherence/src/LLBank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/LLBank.bsv
@@ -55,6 +55,7 @@ import RandomReplace::*;
 import PerformanceMonitor::*;
 import BlueUtils::*;
 `endif
+import StatCounters::*;
 
 export LLCRqStuck(..);
 export LLBank(..);
@@ -107,7 +108,7 @@ interface LLBank#(
     method Action setPerfStatus(Bool stats);
     method Data getPerfData(LLCPerfType t);
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsLL events;
 `endif
 endinterface
 
@@ -243,7 +244,7 @@ module mkLLBank#(
     Count#(Data) dmaStReqCnt <- mkCount(0);
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsCache)) perf_events <- mkDRegOR (2, unpack (0));
+    Array #(Reg #(EventsLL)) perf_events <- mkDRegOR (2, unpack (0));
 `endif
 function Action incrMissCnt(cRqIndexT idx, Bool isDma);
 action
@@ -261,7 +262,7 @@ action
     end
 `endif
 `ifdef PERFORMANCE_MONITORING
-    EventsCache events = unpack (0);
+    EventsLL events = unpack (0);
     events.evt_LD_MISS_LAT = saturating_truncate(lat); // Don't support seperate DMA counts.
     events.evt_LD_MISS = 1;
     perf_events[1] <= events;
@@ -643,7 +644,7 @@ endfunction
                 // don't deq info, do ld next time
                 doLdAfterReplace <= True;
 `ifdef PERFORMANCE_MONITORING
-                EventsCache events = unpack (0);
+                EventsLL events = unpack (0);
                 events.evt_ST_MISS = 1;
                 perf_events[0] <= events;
 `endif
@@ -1546,7 +1547,7 @@ endfunction
         endcase);
     endmethod
     `ifdef PERFORMANCE_MONITORING
-        method EventsCache events = perf_events[0];
+        method EventsLL events = perf_events[0];
     `endif
 endmodule
 

--- a/src_Core/RISCY_OOO/coherence/src/LLBank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/LLBank.bsv
@@ -53,9 +53,9 @@ import ConfigReg::*;
 import RandomReplace::*;
 `ifdef PERFORMANCE_MONITORING
 import PerformanceMonitor::*;
+import StatCounters::*;
 import BlueUtils::*;
 `endif
-import StatCounters::*;
 
 export LLCRqStuck(..);
 export LLBank(..);

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -61,6 +61,7 @@ import CHERICC_Fat::*;
 import ISA_Decls_CHERI::*;
 `ifdef PERFORMANCE_MONITORING
 import BlueUtils::*;
+import StatCounters::*;
 `endif
 
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
@@ -1311,19 +1311,19 @@ module mkCommitStage#(CommitInput inIfc)(CommitStage);
 `endif
 `ifdef PERFORMANCE_MONITORING
         EventsCore events = unpack(0);
-        events.evt_BRANCH = brCnt;
-        events.evt_JAL = jmpCnt;
-        events.evt_JALR = jrCnt;
-        events.evt_AUIPC = auipcCnt; // XXX
-        events.evt_LOAD = ldCnt;
-        events.evt_STORE = stCnt;
-        events.evt_LR = lrCnt;
-        events.evt_SC = scCnt;
-        events.evt_AMO = amoCnt;
-        events.evt_SERIAL_SHIFT = shiftCnt;
-        events.evt_INT_MUL_DIV_REM = muldivCnt;
-        events.evt_FP = fpuCnt;
-        events.evt_FENCE = fenceCnt;
+        events.evt_BRANCH = zeroExtend(brCnt);
+        events.evt_JAL = zeroExtend(jmpCnt);
+        events.evt_JALR = zeroExtend(jrCnt);
+        events.evt_AUIPC = zeroExtend(auipcCnt); // XXX
+        events.evt_LOAD = zeroExtend(ldCnt);
+        events.evt_STORE = zeroExtend(stCnt);
+        events.evt_LR = zeroExtend(lrCnt);
+        events.evt_SC = zeroExtend(scCnt);
+        events.evt_AMO = zeroExtend(amoCnt);
+        events.evt_SERIAL_SHIFT = zeroExtend(shiftCnt);
+        events.evt_INT_MUL_DIV_REM = zeroExtend(muldivCnt);
+        events.evt_FP = zeroExtend(fpuCnt);
+        events.evt_FENCE = zeroExtend(fenceCnt);
         events_reg <= events;
 `ifdef CONTRACTS_VERIFY
         inIfc.updateTargets(targets);

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
@@ -60,6 +60,7 @@ import RenameDebugIF::*;
 import CHERICap::*;
 import CHERICC_Fat::*;
 import ISA_Decls_CHERI::*;
+import StatCounters::*;
 
 `ifdef RVFI
 import RVFI_DII_Types::*;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
@@ -72,9 +72,9 @@ import CacheUtils::*;
 `ifdef PERFORMANCE_MONITORING
 import PerformanceMonitor::*;
 import BlueUtils::*;
+import StatCounters::*;
 import DReg::*;
 `endif
-import StatCounters::*;
 
 import Cur_Cycle :: *;
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/MemExePipeline.bsv
@@ -74,6 +74,7 @@ import PerformanceMonitor::*;
 import BlueUtils::*;
 import DReg::*;
 `endif
+import StatCounters::*;
 
 import Cur_Cycle :: *;
 
@@ -243,7 +244,7 @@ interface MemExePipeline;
 `endif
     method Data getPerf(ExeStagePerfType t);
 `ifdef PERFORMANCE_MONITORING
-    method EventsCoreMem events;
+    method EventsCore events;
 `ifdef CONTRACTS_VERIFY
     method EventsTransExe events_trans;
 `endif
@@ -288,7 +289,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
 `endif
 
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsCoreMem)) events_reg <- mkDRegOR (5, unpack (0));
+    Array #(Reg #(EventsCore)) events_reg <- mkDRegOR (5, unpack (0));
 `ifdef CONTRACTS_VERIFY
     Reg#(EventsTransExe) events_trans_reg <- mkDReg(unpack(0));
 `endif
@@ -361,7 +362,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
             end
 `endif
 `ifdef PERFORMANCE_MONITORING
-            EventsCoreMem events = unpack(0);
+            EventsCore events = unpack(0);
             events.evt_LOAD_WAIT = saturating_truncate(lat);
             events.evt_MEM_CAP_LOAD_TAG_SET = (d.tag) ? 1 : 0;
             events_reg[1] <= events;
@@ -389,7 +390,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
             end
 `endif
 `ifdef PERFORMANCE_MONITORING
-            EventsCoreMem events = unpack(0);
+            EventsCore events = unpack(0);
             if (pack(waitSt.shiftedBE) == -1) events.evt_MEM_CAP_STORE = 1;
             events.evt_STORE_WAIT = saturating_truncate(lat);
             events_reg[2] <= events;
@@ -416,7 +417,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
             end
 `endif
 `ifdef PERFORMANCE_MONITORING
-            EventsCoreMem events = unpack(0);
+            EventsCore events = unpack(0);
             if (pack(e.byteEn) == -1) events.evt_MEM_CAP_STORE = 1;
             events.evt_STORE_WAIT = saturating_truncate(lat);
             events_reg[2] <= events;
@@ -563,7 +564,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
             MemTaggedData d = x.mem_func == Amo ? toMemData : shiftData; // XXX don't shift for AMO
             lsq.updateData(stTag, d);
 `ifdef PERFORMANCE_MONITORING
-            EventsCoreMem events = unpack(0);
+            EventsCore events = unpack(0);
             events.evt_MEM_CAP_STORE_TAG_SET = (d.tag) ? 1 : 0;
             events_reg[4] <= events;
 `endif
@@ -755,7 +756,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
         SBSearchRes sbRes = stb.search(info.paddr, info.shiftedBE);
 `endif
 `ifdef PERFORMANCE_MONITORING
-        EventsCoreMem events = unpack(0);
+        EventsCore events = unpack(0);
         if (info.shiftedBE == DataMemAccess (unpack(~0))) events.evt_MEM_CAP_LOAD = 1;
 `endif
         // search LSQ
@@ -1372,7 +1373,7 @@ module mkMemExePipeline#(MemExeInput inIfc)(MemExePipeline);
         end
 `endif
 `ifdef PERFORMANCE_MONITORING
-        EventsCoreMem events = unpack(0);
+        EventsCore events = unpack(0);
         events.evt_SC_SUCCESS = 1;
         events_reg[3] <= events;
 `endif

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
@@ -67,6 +67,7 @@ import SplitLSQ::*;
 import CHERICap::*;
 import CHERICC_Fat::*;
 import ISA_Decls_CHERI::*;
+import StatCounters::*;
 
 import Cur_Cycle :: *;
 
@@ -1186,7 +1187,7 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
 `endif
 `ifdef PERFORMANCE_MONITORING
         EventsTransExe events = unpack(0);
-        events.evt_RENAMED_INST = renameCnt;
+        events.evt_RENAMED_INST = zeroExtend(renameCnt);
         events_reg <= events;
 `endif
 

--- a/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DTlb.bsv
@@ -56,6 +56,7 @@ import Ehr::*;
 import PerformanceMonitor::*;
 import CCTypes::*;
 import BlueUtils::*;
+import StatCounters::*;
 `endif
 
 export DTlbReq(..);
@@ -123,7 +124,7 @@ interface DTlb#(type instT);
     // performance
     interface Perf#(L1TlbPerfType) perf;
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsL1D events;
 `endif
 endinterface
 
@@ -244,7 +245,7 @@ module mkDTlb#(
     endrule
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsCache)) perf_events <- mkDRegOR (3, unpack (0));
+    Array #(Reg #(EventsL1D)) perf_events <- mkDRegOR (3, unpack (0));
 `endif
 
     // do flush: start when all misses resolve
@@ -257,7 +258,7 @@ module mkDTlb#(
         waitFlushP <= True;
         if(verbose) $display("[DTLB] flush begin");
 `ifdef PERFORMANCE_MONITORING
-        EventsCache ev = unpack(0);
+        EventsL1D ev = unpack(0);
         ev.evt_TLB_FLUSH = 1;
         perf_events[2] <= ev;
 `endif
@@ -368,7 +369,7 @@ module mkDTlb#(
         end
 `endif
 `ifdef PERFORMANCE_MONITORING
-        EventsCache ev = unpack(0);
+        EventsL1D ev = unpack(0);
         ev.evt_TLB_MISS_LAT = saturating_truncate(lat);
         ev.evt_TLB_MISS = 1;
         perf_events[0] <= ev;
@@ -564,7 +565,7 @@ module mkDTlb#(
         end
 `endif
 `ifdef PERFORMANCE_MONITORING
-        EventsCache ev = unpack(0);
+        EventsL1D ev = unpack(0);
         ev.evt_TLB = 1;
         perf_events[1] <= ev;
 `endif
@@ -657,6 +658,6 @@ module mkDTlb#(
         endmethod
     endinterface
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = perf_events[0];
+    method EventsL1D events = perf_events[0];
 `endif
 endmodule

--- a/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ITlb.bsv
@@ -53,6 +53,7 @@ import LatencyTimer::*;
 import PerformanceMonitor::*;
 import CCTypes::*;
 import BlueUtils::*;
+import StatCounters::*;
 `endif
 
 // currently blocking
@@ -91,7 +92,7 @@ interface ITlb;
     // performance
     interface Perf#(L1TlbPerfType) perf;
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsL1I events;
 `endif
 endinterface
 
@@ -154,7 +155,7 @@ module mkITlb(ITlb::ITlb);
     endrule
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsCache)) perf_events <- mkDRegOR (3, unpack (0));
+    Array #(Reg #(EventsL1I)) perf_events <- mkDRegOR (3, unpack (0));
 `endif
 
     // do flush: only start when all misses resolve
@@ -165,7 +166,7 @@ module mkITlb(ITlb::ITlb);
         waitFlushP <= True;
         if(verbose) $display("ITLB %m: flush begin");
 `ifdef PERFORMANCE_MONITORING
-        EventsCache ev = unpack(0);
+        EventsL1I ev = unpack(0);
         ev.evt_TLB_FLUSH = 1;
         perf_events[2] <= ev;
 `endif
@@ -229,7 +230,7 @@ module mkITlb(ITlb::ITlb);
         end
 `endif
 `ifdef PERFORMANCE_MONITORING
-        EventsCache ev = unpack(0);
+        EventsL1I ev = unpack(0);
         ev.evt_TLB_MISS_LAT = saturating_truncate(lat);
         ev.evt_TLB_MISS = 1;
         perf_events[0] <= ev;
@@ -363,7 +364,7 @@ module mkITlb(ITlb::ITlb);
                 end
 `endif
 `ifdef PERFORMANCE_MONITORING
-                EventsCache ev = unpack(0);
+                EventsL1I ev = unpack(0);
                 ev.evt_TLB = 1;
                 perf_events[1] <= ev;
 `endif
@@ -416,6 +417,6 @@ module mkITlb(ITlb::ITlb);
         endmethod
     endinterface
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = perf_events[0];
+    method EventsL1I events = perf_events[0];
 `endif
 endmodule

--- a/src_Core/RISCY_OOO/procs/lib/L1CoCache.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/L1CoCache.bsv
@@ -59,6 +59,7 @@ import SelfInvL1Pipe::*;
 import SelfInvL1Bank::*;
 import SelfInvIPipe::*;
 import SelfInvIBank::*;
+import StatCounters::*;
 
 export L1Num;
 export LgL1WayNum;
@@ -179,7 +180,7 @@ interface DCoCache;
     method Action resetLinkAddr;
     interface Perf#(L1DPerfType) perf;
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsL1D events;
 `endif
 
     interface ChildCacheToParent#(L1Way, void) to_parent;
@@ -271,7 +272,7 @@ module mkDCoCache#(L1ProcResp#(DProcReqId) procResp)(DCoCache);
         endmethod
     endinterface
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = cache.events;
+    method EventsL1D events = cache.events;
 `endif
 
     interface to_parent = cache.to_parent;
@@ -373,7 +374,7 @@ interface ICoCache;
     method Bool flush_done;
     interface Perf#(L1IPerfType) perf;
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsL1I events;
 `endif
 
     interface ChildCacheToParent#(L1Way, void) to_parent;
@@ -446,7 +447,7 @@ module mkICoCache(ICoCache);
         endmethod
     endinterface
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = cache.events;
+    method EventsL1I events = cache.events;
 `endif
 
     interface to_parent = cache.to_parent;

--- a/src_Core/RISCY_OOO/procs/lib/L2Tlb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/L2Tlb.bsv
@@ -58,6 +58,7 @@ import LatencyTimer::*;
 import PerformanceMonitor::*;
 import CCTypes::*;
 import BlueUtils::*;
+import StatCounters::*;
 `endif
 
 // for SV39 only
@@ -120,7 +121,7 @@ interface L2Tlb;
     // performace
     interface Perf#(L2TlbPerfType) perf;
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsLL events;
 `endif
 endinterface
 
@@ -286,7 +287,7 @@ module mkL2Tlb(L2Tlb::L2Tlb);
     endrule
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsCache)) perf_events <- mkDRegOR (3, unpack (0));
+    Array #(Reg #(EventsLL)) perf_events <- mkDRegOR (3, unpack (0));
 `endif
 
     // when flushing is true, since both I and D TLBs have finished flush and
@@ -301,7 +302,7 @@ module mkL2Tlb(L2Tlb::L2Tlb);
         doAssert(!rqFromCQ.notEmpty, "cannot have new req");
         doAssert(readVEhr(0, pendValid) == replicate(False), "cannot have pending req");
 `ifdef PERFORMANCE_MONITORING
-        EventsCache ev = unpack(0);
+        EventsLL ev = unpack(0);
         ev.evt_TLB_FLUSH = 1;
         perf_events[2] <= ev;
 `endif
@@ -420,7 +421,7 @@ module mkL2Tlb(L2Tlb::L2Tlb);
             end
 `endif
 `ifdef PERFORMANCE_MONITORING
-            EventsCache ev = unpack(0);
+            EventsLL ev = unpack(0);
             ev.evt_TLB = 1;
             perf_events[1] <= ev;
 `endif
@@ -433,7 +434,7 @@ module mkL2Tlb(L2Tlb::L2Tlb);
             // update 4KB array replacement, no need to touch MG array
             tlb4KB.deqResp(Valid (resp4KB.way));
 `ifdef PERFORMANCE_MONITORING
-            EventsCache ev = unpack(0);
+            EventsLL ev = unpack(0);
             ev.evt_TLB = 1;
             perf_events[1] <= ev;
 `endif
@@ -457,7 +458,7 @@ module mkL2Tlb(L2Tlb::L2Tlb);
             end
 `endif
 `ifdef PERFORMANCE_MONITORING
-            EventsCache ev = unpack(0);
+            EventsLL ev = unpack(0);
             ev.evt_TLB_MISS = 1;
             perf_events[0] <= ev;
 `endif
@@ -695,7 +696,7 @@ module mkL2Tlb(L2Tlb::L2Tlb);
                 });
 `ifdef PERFORMANCE_MONITORING
                 // page table walks are counted as accesses
-                EventsCache ev = unpack(0);
+                EventsLL ev = unpack(0);
                 ev.evt_TLB = 1;
                 perf_events[1] <= ev;
 `endif
@@ -714,7 +715,7 @@ module mkL2Tlb(L2Tlb::L2Tlb);
                     end
 `endif
 `ifdef PERFORMANCE_MONITORING
-                    EventsCache ev = unpack(0);
+                    EventsLL ev = unpack(0);
                     ev.evt_TLB_MISS = 1;
                     perf_events[0] <= ev;
 `endif
@@ -807,6 +808,6 @@ module mkL2Tlb(L2Tlb::L2Tlb);
         endmethod
     endinterface
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = perf_events[0];
+    method EventsLL events = perf_events[0];
 `endif
 endmodule

--- a/src_Core/RISCY_OOO/procs/lib/LLCache.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/LLCache.bsv
@@ -55,6 +55,7 @@ import SelfInvLLBank::*;
 import L1CoCache::*;
 import LLCDmaConnect::*;
 import Performance::*;
+import StatCounters::*;
 
 // Last-Level
 
@@ -255,7 +256,7 @@ interface LLCache;
     // performance
     interface Perf#(LLCPerfType) perf;
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events;
+    method EventsLL events;
 `endif
 endinterface
 
@@ -466,6 +467,6 @@ module mkLLCache(LLCache);
         endmethod
     endinterface
 `ifdef PERFORMANCE_MONITORING
-    method EventsCache events = cache.events;
+    method EventsLL events = cache.events;
 `endif
 endmodule

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -1049,81 +1049,10 @@ endfunction
 function x addPc(x cap, Bit#(12) inc) provisos (Add#(f, 12, c), CHERICap::CHERICap#(x, a, b, c, d, e)) = setAddrUnsafe(cap, getAddr(cap) + signExtend(inc));
 
 `ifdef PERFORMANCE_MONITORING
-//`ifdef CONTRACTS_VERIFY
-//typedef 128 No_Of_Evts;
-//`else
-//typedef 112 No_Of_Evts;
-//`endif
 typedef   8 Report_Width;
 typedef  64 Counter_Width;
 typedef  29 No_Of_Ctrs;
 
-//typedef struct {
-//   SupCnt evt_REDIRECT;
-//   SupCnt evt_TRAP;
-//   SupCnt evt_BRANCH;
-//   SupCnt evt_JAL;
-//   SupCnt evt_JALR;
-//   SupCnt evt_AUIPC;
-//   SupCnt evt_LOAD;
-//   SupCnt evt_STORE;
-//   SupCnt evt_LR;
-//   SupCnt evt_SC;
-//   SupCnt evt_AMO;
-//   SupCnt evt_SERIAL_SHIFT;
-//   SupCnt evt_INT_MUL_DIV_REM;
-//   SupCnt evt_FP;
-//   SupCnt evt_SC_SUCCESS;
-//   SupCnt evt_LOAD_WAIT;
-//   SupCnt evt_STORE_WAIT;
-//   SupCnt evt_FENCE;
-//   SupCnt evt_F_BUSY_NO_CONSUME; // XXX
-//   SupCnt evt_D_BUSY_NO_CONSUME; // XXX
-//   SupCnt evt_1_BUSY_NO_CONSUME; // XXX
-//   SupCnt evt_2_BUSY_NO_CONSUME; // XXX
-//   SupCnt evt_3_BUSY_NO_CONSUME; // XXX
-//   SupCnt evt_IMPRECISE_SETBOUND; // XXX
-//   SupCnt evt_UNREPRESENTABLE_CAP; // XXX
-//   SupCnt evt_MEM_CAP_LOAD;
-//   SupCnt evt_MEM_CAP_STORE;
-//   SupCnt evt_MEM_CAP_LOAD_TAG_SET;
-//   SupCnt evt_MEM_CAP_STORE_TAG_SET;
-//} EventsCore deriving (Bits, FShow);
-//typedef TDiv#(SizeOf#(EventsCore),SizeOf#(SupCnt)) EventsCoreElements;
-//
-//typedef Bit#(Report_Width) HpmRpt;
-//typedef struct {
-//   HpmRpt evt_REDIRECT;
-//   HpmRpt evt_TRAP;
-//   HpmRpt evt_BRANCH;
-//   HpmRpt evt_JAL;
-//   HpmRpt evt_JALR;
-//   HpmRpt evt_AUIPC;
-//   HpmRpt evt_LOAD;
-//   HpmRpt evt_STORE;
-//   HpmRpt evt_LR;
-//   HpmRpt evt_SC;
-//   HpmRpt evt_AMO;
-//   HpmRpt evt_SERIAL_SHIFT;
-//   HpmRpt evt_INT_MUL_DIV_REM;
-//   HpmRpt evt_FP;
-//   HpmRpt evt_SC_SUCCESS;
-//   HpmRpt evt_LOAD_WAIT;
-//   HpmRpt evt_STORE_WAIT;
-//   HpmRpt evt_FENCE;
-//   HpmRpt evt_F_BUSY_NO_CONSUME; // XXX
-//   HpmRpt evt_D_BUSY_NO_CONSUME; // XXX
-//   HpmRpt evt_1_BUSY_NO_CONSUME; // XXX
-//   HpmRpt evt_2_BUSY_NO_CONSUME; // XXX
-//   HpmRpt evt_3_BUSY_NO_CONSUME; // XXX
-//   HpmRpt evt_IMPRECISE_SETBOUND; // XXX
-//   HpmRpt evt_UNREPRESENTABLE_CAP; // XXX
-//   HpmRpt evt_MEM_CAP_LOAD;
-//   HpmRpt evt_MEM_CAP_STORE;
-//   HpmRpt evt_MEM_CAP_LOAD_TAG_SET;
-//   HpmRpt evt_MEM_CAP_STORE_TAG_SET;
-//} EventsCoreMem deriving (Bits, FShow); // Memory needs more space for reporting delays
-//typedef TDiv#(SizeOf#(EventsCoreMem),Report_Width) EventsCoreMemElements;
 
 typedef struct {
    SupCnt evt_RENAMED_INST;

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -1058,72 +1058,72 @@ typedef   8 Report_Width;
 typedef  64 Counter_Width;
 typedef  29 No_Of_Ctrs;
 
-typedef struct {
-   SupCnt evt_REDIRECT;
-   SupCnt evt_TRAP;
-   SupCnt evt_BRANCH;
-   SupCnt evt_JAL;
-   SupCnt evt_JALR;
-   SupCnt evt_AUIPC;
-   SupCnt evt_LOAD;
-   SupCnt evt_STORE;
-   SupCnt evt_LR;
-   SupCnt evt_SC;
-   SupCnt evt_AMO;
-   SupCnt evt_SERIAL_SHIFT;
-   SupCnt evt_INT_MUL_DIV_REM;
-   SupCnt evt_FP;
-   SupCnt evt_SC_SUCCESS;
-   SupCnt evt_LOAD_WAIT;
-   SupCnt evt_STORE_WAIT;
-   SupCnt evt_FENCE;
-   SupCnt evt_F_BUSY_NO_CONSUME; // XXX
-   SupCnt evt_D_BUSY_NO_CONSUME; // XXX
-   SupCnt evt_1_BUSY_NO_CONSUME; // XXX
-   SupCnt evt_2_BUSY_NO_CONSUME; // XXX
-   SupCnt evt_3_BUSY_NO_CONSUME; // XXX
-   SupCnt evt_IMPRECISE_SETBOUND; // XXX
-   SupCnt evt_UNREPRESENTABLE_CAP; // XXX
-   SupCnt evt_MEM_CAP_LOAD;
-   SupCnt evt_MEM_CAP_STORE;
-   SupCnt evt_MEM_CAP_LOAD_TAG_SET;
-   SupCnt evt_MEM_CAP_STORE_TAG_SET;
-} EventsCore deriving (Bits, FShow);
-typedef TDiv#(SizeOf#(EventsCore),SizeOf#(SupCnt)) EventsCoreElements;
-
-typedef Bit#(Report_Width) HpmRpt;
-typedef struct {
-   HpmRpt evt_REDIRECT;
-   HpmRpt evt_TRAP;
-   HpmRpt evt_BRANCH;
-   HpmRpt evt_JAL;
-   HpmRpt evt_JALR;
-   HpmRpt evt_AUIPC;
-   HpmRpt evt_LOAD;
-   HpmRpt evt_STORE;
-   HpmRpt evt_LR;
-   HpmRpt evt_SC;
-   HpmRpt evt_AMO;
-   HpmRpt evt_SERIAL_SHIFT;
-   HpmRpt evt_INT_MUL_DIV_REM;
-   HpmRpt evt_FP;
-   HpmRpt evt_SC_SUCCESS;
-   HpmRpt evt_LOAD_WAIT;
-   HpmRpt evt_STORE_WAIT;
-   HpmRpt evt_FENCE;
-   HpmRpt evt_F_BUSY_NO_CONSUME; // XXX
-   HpmRpt evt_D_BUSY_NO_CONSUME; // XXX
-   HpmRpt evt_1_BUSY_NO_CONSUME; // XXX
-   HpmRpt evt_2_BUSY_NO_CONSUME; // XXX
-   HpmRpt evt_3_BUSY_NO_CONSUME; // XXX
-   HpmRpt evt_IMPRECISE_SETBOUND; // XXX
-   HpmRpt evt_UNREPRESENTABLE_CAP; // XXX
-   HpmRpt evt_MEM_CAP_LOAD;
-   HpmRpt evt_MEM_CAP_STORE;
-   HpmRpt evt_MEM_CAP_LOAD_TAG_SET;
-   HpmRpt evt_MEM_CAP_STORE_TAG_SET;
-} EventsCoreMem deriving (Bits, FShow); // Memory needs more space for reporting delays
-typedef TDiv#(SizeOf#(EventsCoreMem),Report_Width) EventsCoreMemElements;
+//typedef struct {
+//   SupCnt evt_REDIRECT;
+//   SupCnt evt_TRAP;
+//   SupCnt evt_BRANCH;
+//   SupCnt evt_JAL;
+//   SupCnt evt_JALR;
+//   SupCnt evt_AUIPC;
+//   SupCnt evt_LOAD;
+//   SupCnt evt_STORE;
+//   SupCnt evt_LR;
+//   SupCnt evt_SC;
+//   SupCnt evt_AMO;
+//   SupCnt evt_SERIAL_SHIFT;
+//   SupCnt evt_INT_MUL_DIV_REM;
+//   SupCnt evt_FP;
+//   SupCnt evt_SC_SUCCESS;
+//   SupCnt evt_LOAD_WAIT;
+//   SupCnt evt_STORE_WAIT;
+//   SupCnt evt_FENCE;
+//   SupCnt evt_F_BUSY_NO_CONSUME; // XXX
+//   SupCnt evt_D_BUSY_NO_CONSUME; // XXX
+//   SupCnt evt_1_BUSY_NO_CONSUME; // XXX
+//   SupCnt evt_2_BUSY_NO_CONSUME; // XXX
+//   SupCnt evt_3_BUSY_NO_CONSUME; // XXX
+//   SupCnt evt_IMPRECISE_SETBOUND; // XXX
+//   SupCnt evt_UNREPRESENTABLE_CAP; // XXX
+//   SupCnt evt_MEM_CAP_LOAD;
+//   SupCnt evt_MEM_CAP_STORE;
+//   SupCnt evt_MEM_CAP_LOAD_TAG_SET;
+//   SupCnt evt_MEM_CAP_STORE_TAG_SET;
+//} EventsCore deriving (Bits, FShow);
+//typedef TDiv#(SizeOf#(EventsCore),SizeOf#(SupCnt)) EventsCoreElements;
+//
+//typedef Bit#(Report_Width) HpmRpt;
+//typedef struct {
+//   HpmRpt evt_REDIRECT;
+//   HpmRpt evt_TRAP;
+//   HpmRpt evt_BRANCH;
+//   HpmRpt evt_JAL;
+//   HpmRpt evt_JALR;
+//   HpmRpt evt_AUIPC;
+//   HpmRpt evt_LOAD;
+//   HpmRpt evt_STORE;
+//   HpmRpt evt_LR;
+//   HpmRpt evt_SC;
+//   HpmRpt evt_AMO;
+//   HpmRpt evt_SERIAL_SHIFT;
+//   HpmRpt evt_INT_MUL_DIV_REM;
+//   HpmRpt evt_FP;
+//   HpmRpt evt_SC_SUCCESS;
+//   HpmRpt evt_LOAD_WAIT;
+//   HpmRpt evt_STORE_WAIT;
+//   HpmRpt evt_FENCE;
+//   HpmRpt evt_F_BUSY_NO_CONSUME; // XXX
+//   HpmRpt evt_D_BUSY_NO_CONSUME; // XXX
+//   HpmRpt evt_1_BUSY_NO_CONSUME; // XXX
+//   HpmRpt evt_2_BUSY_NO_CONSUME; // XXX
+//   HpmRpt evt_3_BUSY_NO_CONSUME; // XXX
+//   HpmRpt evt_IMPRECISE_SETBOUND; // XXX
+//   HpmRpt evt_UNREPRESENTABLE_CAP; // XXX
+//   HpmRpt evt_MEM_CAP_LOAD;
+//   HpmRpt evt_MEM_CAP_STORE;
+//   HpmRpt evt_MEM_CAP_LOAD_TAG_SET;
+//   HpmRpt evt_MEM_CAP_STORE_TAG_SET;
+//} EventsCoreMem deriving (Bits, FShow); // Memory needs more space for reporting delays
+//typedef TDiv#(SizeOf#(EventsCoreMem),Report_Width) EventsCoreMemElements;
 
 typedef struct {
    SupCnt evt_RENAMED_INST;

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -1049,11 +1049,11 @@ endfunction
 function x addPc(x cap, Bit#(12) inc) provisos (Add#(f, 12, c), CHERICap::CHERICap#(x, a, b, c, d, e)) = setAddrUnsafe(cap, getAddr(cap) + signExtend(inc));
 
 `ifdef PERFORMANCE_MONITORING
-`ifdef CONTRACTS_VERIFY
-typedef 128 No_Of_Evts;
-`else
-typedef 112 No_Of_Evts;
-`endif
+//`ifdef CONTRACTS_VERIFY
+//typedef 128 No_Of_Evts;
+//`else
+//typedef 112 No_Of_Evts;
+//`endif
 typedef   8 Report_Width;
 typedef  64 Counter_Width;
 typedef  29 No_Of_Ctrs;

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -1054,14 +1054,6 @@ typedef  64 Counter_Width;
 typedef  29 No_Of_Ctrs;
 
 
-typedef struct {
-   SupCnt evt_RENAMED_INST;
-   SupCnt evt_WILD_JUMP;
-   SupCnt evt_WILD_EXCEPTION;
-} EventsTransExe deriving (Bits, FShow);
-typedef TDiv#(SizeOf#(EventsTransExe),SizeOf#(SupCnt)) EventsTransExeElements;
-`endif
-
 function Bit#(outWidth) hash(Bit#(inWidth) in)
     provisos(Add#(a__, inWidth, TMul#(TDiv#(inWidth, outWidth), outWidth)),
              Add#(1, b__, TDiv#(inWidth, outWidth)));


### PR DESCRIPTION
I removed all knowledge about counter event mappings from the .bsv files and used the repo 'RISCV_HPM_Events' as the source instead. This makes things consistent across different implementations.