### PR TITLE
Added ccopytype_bypass

### DIFF
--- a/src_Core/RISCY_OOO/procs/lib/CapChecks.bsvi
+++ b/src_Core/RISCY_OOO/procs/lib/CapChecks.bsvi
@@ -22,4 +22,5 @@
 `CAP_CHECK_FIELD(src1_derivable,"src1_derivable")
 `CAP_CHECK_FIELD(cfromptr_bypass,"cfromptr_bypass")
 `CAP_CHECK_FIELD(ccseal_bypass,"ccseal_bypass")
+`CAP_CHECK_FIELD(ccopytype_bypass,"ccopytype_bypass")
 `CAP_CHECK_FIELD(cap_exact,"cap_exact")

--- a/src_Core/RISCY_OOO/procs/lib/Decode.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Decode.bsv
@@ -1174,6 +1174,7 @@ function DecodeResult decode(Instruction inst, Bool cap_mode);
                             dInst.capChecks.check_low_src = Src1Type;
                             dInst.capChecks.check_high_src = Src1Type;
                             dInst.capChecks.check_inclusive = False;
+                            dInst.capChecks.ccopytype_bypass = True;
 
                             dInst.iType = Cap;
                             regs.dst = Valid(tagged Gpr rd);

--- a/src_Core/RISCY_OOO/procs/lib/Exec.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Exec.bsv
@@ -424,6 +424,10 @@ function ExecResult basicExec(DecodedInst dInst, CapPipe rVal1, CapPipe rVal2, C
         capException = Invalid;
         boundsCheck = Invalid;
     end
+    if (dInst.capChecks.ccopytype_bypass && isValidCap(rVal1) && getKind(rVal1) == UNSEALED && !validAsType(rVal1, zeroExtend(getKind(rVal1).SEALED_WITH_TYPE))) begin
+        capException = Invalid;
+        boundsCheck = Invalid;
+    end
 
     cf.nextPc = setKind(cf.nextPc, UNSEALED);
     cf.mispredict = cf.nextPc != ppc;

--- a/src_Core/RISCY_OOO/procs/lib/Exec.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Exec.bsv
@@ -5,6 +5,7 @@
 //     Copyright (c) 2020 Alexandre Joannou
 //     Copyright (c) 2020 Peter Rugg
 //     Copyright (c) 2020 Jonathan Woodruff
+//     Copyright (c) 2021 Marno van der Maas
 //     All rights reserved.
 //
 //     This software was developed by SRI International and the University of

--- a/src_Core/RISCY_OOO/procs/lib/Exec.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Exec.bsv
@@ -424,7 +424,7 @@ function ExecResult basicExec(DecodedInst dInst, CapPipe rVal1, CapPipe rVal2, C
         capException = Invalid;
         boundsCheck = Invalid;
     end
-    if (dInst.capChecks.ccopytype_bypass && isValidCap(rVal1) && getKind(rVal1) == UNSEALED && !validAsType(rVal1, zeroExtend(getKind(rVal1).SEALED_WITH_TYPE))) begin
+    if (dInst.capChecks.ccopytype_bypass && isValidCap(rVal2) && getKind(rVal2) == UNSEALED && (getKind(rVal1) matches tagged SEALED_WITH_TYPE .t ? !validAsType(rVal2, zeroExtend(t)) : True)) begin
         capException = Invalid;
         boundsCheck = Invalid;
     end


### PR DESCRIPTION
This fix should stop Toooba from throwing a length exception when CCopyType is called on a reserve otype.