### PR TITLE
Restructure makefiles so that all common and branch-specific flags/files

### DIFF
--- a/builds/RV64ACDFIMSUxCHERI_Toooba_bluesim/Makefile
+++ b/builds/RV64ACDFIMSUxCHERI_Toooba_bluesim/Makefile
@@ -6,7 +6,7 @@ ARCH ?= RV64ACDFIMSUxCHERI
 # ================================================================
 # Path to RISCY-OOO sources not included in Common
 
-EXTRA_DIRS = $(RISCY_HOME)/../../src_Verifier:$(RISCY_HOME)/../../src_Verifier/BSV-RVFI-DII
+EXTRA_DIRS = $(REPO)/src_Verifier:$(REPO)/src_Verifier/BSV-RVFI-DII
 
 # ================================================================
 # RISC-V config macros passed into Bluespec 'bsc' compiler
@@ -16,14 +16,14 @@ EXTRA_DIRS = $(RISCY_HOME)/../../src_Verifier:$(RISCY_HOME)/../../src_Verifier/B
 TEST ?= rv64ui-p-add
 
 #================================================================
-# Common boilerplate rules
-
-include $(REPO)/builds/Resources/Include_Common.mk
-
-#================================================================
 # Parameter settings for MIT RISCY
 
 include $(REPO)/builds/Resources/Include_RISCY_Config.mk
+
+#================================================================
+# Common boilerplate rules
+
+include $(REPO)/builds/Resources/Include_Common.mk
 
 #================================================================
 # Makefile rules for building for specific simulator: bluesim

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -56,7 +56,6 @@ BSC_COMPILATION_FLAGS += \
 	-D BLUESIM \
 	-D PERFORMANCE_MONITORING \
 	-D RAS_HIT_TRACING \
-	-D NO_SPEC_TRAINING -D NO_SPEC_REDIRECT -D NO_SPEC_STRAIGHT_PATH -D SPEC_RSB_FIXUP -D MELTDOWN_CF \
 	-keep-fires -aggressive-conditions -no-warn-action-shadowing -check-assert \
 	-suppress-warnings G0020 -steps-max-intervals 10000000   \
 	-steps-warn-interval 1000000 \
@@ -113,17 +112,17 @@ TagTableStructure.bsv: $(REPO)/libs/TagController/tagsparams.py
 
 .PHONY: generate_hpm_vector
 generate_hpm_vector: GenerateHPMVector.bsv
-GenerateHPMVector.bsv: $(RISCVHPMEVENTSDIR)/parse_counters.py
+GenerateHPMVector.bsv: $(RISCV_HPM_EVENTS_DIR)/parse_counters.py
 	@echo "INFO: Re-generating GenerateHPMVector bluespec file"
-	$^ $(RISCVHPMEVENTSDIR)/counters.yaml -m ProcTypes -b $@
+	$^ $(RISCV_HPM_EVENTS_DIR)/counters.yaml -m ProcTypes -b $@
 	@echo "INFO: Re-generated GenerateHPMVector bluespec file"
 
 
 .PHONY: stat_counters
 stat_counters: StatCounters.bsv
-StatCounters.bsv: $(RISCVHPMEVENTSDIR)/parse_counters.py
+StatCounters.bsv: $(RISCV_HPM_EVENTS_DIR)/parse_counters.py
 	@echo "INFO: Re-generating HPM events struct bluepsec file"
-	$^ $(RISCVHPMEVENTSDIR)/counters.yaml -m ProcTypes -s $@
+	$^ $(RISCV_HPM_EVENTS_DIR)/counters.yaml -m ProcTypes -s $@
 	@echo "INFO: Re-generated HPM events struct bluespec file"
 compile: tagsparams #stat_counters generate_hpm_vector
 

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -33,37 +33,11 @@ help:
 all: compile  simulator
 
 # ================================================================
-# Path to RISCY-OOO sources
-
-RISCY_HOME ?= ../../src_Core/RISCY_OOO
-# RISCY_HOME ?= $(HOME)/Projects/RISCV/MIT-riscy/riscy-OOO
-
-RISCY_DIRS = $(RISCY_HOME)/procs/RV64G_OOO:$(RISCY_HOME)/procs/lib:$(RISCY_HOME)/coherence/src:$(RISCY_HOME)/fpgautils/lib
-
-CONNECTAL_DIRS = $(RISCY_HOME)/connectal/bsv:$(RISCY_HOME)/connectal/tests/spi:$(RISCY_HOME)/connectal/lib/bsv
-
-CHERI_DIRS = $(RISCY_HOME)/../../libs/cheri-cap-lib
-
-# ALL_RISCY_DIRS = $(RISCY_DIRS)
-ALL_RISCY_DIRS = $(EXTRA_DIRS):$(RISCY_DIRS):$(CONNECTAL_DIRS):$(CHERI_DIRS)
-
-# ================================================================
 # Search path for bsc for .bsv files
-
-CORE_DIRS = $(REPO)/src_Core/CPU:$(REPO)/src_Core/ISA:$(REPO)/src_Core/Core:$(REPO)/src_Core/PLIC:$(REPO)/src_Core/Debug_Module:$(REPO)/src_Core/BSV_Additional_Libs
 
 TESTBENCH_DIRS = $(REPO)/src_Testbench/Top:$(REPO)/src_Testbench/SoC
 
-BLUESTUFFDIR ?= $(REPO)/libs/BlueStuff
-include $(BLUESTUFFDIR)/bluestuff.inc.mk # sets the BLUESTUFF_DIRS variable
-
-WINDCOREIFC_DIRS = $(REPO)/libs/WindCoreInterface
-
-TAGCONTROLLER_DIRS = $(REPO)/libs/TagController/TagController:$(REPO)/libs/TagController/TagController/CacheCore
-
-RISCV_HPM_Events_DIR = $(REPO)/libs/RISCV_HPM_Events
-
-BSC_PATH = $(BLUESTUFF_DIRS):$(WINDCOREIFC_DIRS):$(ALL_RISCY_DIRS):$(CORE_DIRS):$(TESTBENCH_DIRS):$(TAGCONTROLLER_DIRS):$(RISCV_HPM_Events_DIR):+
+BSC_PATH += -p +:$(TESTBENCH_DIRS):$(EXTRA_DIRS)
 
 # ----------------
 # Top-level file and module
@@ -76,23 +50,12 @@ TOPMODULE ?= mkTop_HW_Side
 
 BSC_COMPILATION_FLAGS += \
 	-D BSIM \
-	-D RV64 \
-	-D ISA_PRIV_M  -D ISA_PRIV_U  -D ISA_PRIV_S  \
-	-D SV39  \
-	-D ISA_I  -D ISA_M  -D ISA_A  -D ISA_F  -D ISA_D  -D ISA_FD_DIV  -D ISA_C  \
-	-D SHIFT_BARREL    \
 	-D MULT_SYNTH    \
 	-D Near_Mem_Caches    \
 	-D FABRIC64    \
-	-D CheriBusBytes=64 \
-	-D CheriMasterIDWidth=1 \
-	-D CheriTransactionIDWidth=6 \
-	-D CAP128 -D BLUESIM \
-	-D MEM512 \
-	-D RISCV \
+	-D BLUESIM \
 	-D PERFORMANCE_MONITORING \
 	-D RAS_HIT_TRACING \
-	-D TSO_MM \
 	-D NO_SPEC_TRAINING -D NO_SPEC_REDIRECT -D NO_SPEC_STRAIGHT_PATH -D SPEC_RSB_FIXUP -D MELTDOWN_CF \
 	-keep-fires -aggressive-conditions -no-warn-action-shadowing -check-assert \
 	-suppress-warnings G0020 -steps-max-intervals 10000000   \
@@ -150,17 +113,17 @@ TagTableStructure.bsv: $(REPO)/libs/TagController/tagsparams.py
 
 .PHONY: generate_hpm_vector
 generate_hpm_vector: GenerateHPMVector.bsv
-GenerateHPMVector.bsv: $(RISCV_HPM_Events_DIR)/parse_counters.py
+GenerateHPMVector.bsv: $(RISCVHPMEVENTSDIR)/parse_counters.py
 	@echo "INFO: Re-generating GenerateHPMVector bluespec file"
-	$^ $(RISCV_HPM_Events_DIR)/counters.yaml -m ProcTypes -b $@
+	$^ $(RISCVHPMEVENTSDIR)/counters.yaml -m ProcTypes -b $@
 	@echo "INFO: Re-generated GenerateHPMVector bluespec file"
 
 
 .PHONY: stat_counters
 stat_counters: StatCounters.bsv
-StatCounters.bsv: $(RISCV_HPM_Events_DIR)/parse_counters.py
+StatCounters.bsv: $(RISCVHPMEVENTSDIR)/parse_counters.py
 	@echo "INFO: Re-generating HPM events struct bluepsec file"
-	$^ $(RISCV_HPM_Events_DIR)/counters.yaml -m ProcTypes -s $@
+	$^ $(RISCVHPMEVENTSDIR)/counters.yaml -m ProcTypes -s $@
 	@echo "INFO: Re-generated HPM events struct bluespec file"
 compile: tagsparams #stat_counters generate_hpm_vector
 

--- a/builds/Resources/Include_RISCY_Config.mk
+++ b/builds/Resources/Include_RISCY_Config.mk
@@ -107,6 +107,7 @@ BSC_COMPILATION_FLAGS += \
 	-D ISA_PRIV_M  -D ISA_PRIV_S  -D ISA_PRIV_U  \
 	-D SV39 \
 	-D ISA_I  -D ISA_M  -D ISA_A  -D ISA_F  -D ISA_D  -D ISA_FD_DIV  -D ISA_C  \
+	-D NO_SPEC_TRAINING -D NO_SPEC_REDIRECT -D NO_SPEC_STRAIGHT_PATH -D SPEC_RSB_FIXUP -D MELTDOWN_CF \
 	-D CheriBusBytes=64 \
 	-D CheriMasterIDWidth=1 \
 	-D CheriTransactionIDWidth=6
@@ -118,6 +119,7 @@ BSC_COMPILATION_FLAGS += \
 #    -D NO_LOAD_RESP_E
 # various SECURITY related flags
 #    -D PERF_COUNT    -D CHECK_DEADLOCK    -D RENAME_DEBUG ...
+#    -D NO_SPEC_RSB_PUSH -D NO_SPEC_STL -D RVFI
 
 # +RTS -K1G -RTS " --bscflags=" -steps-max-intervals 200  -check-assert
 
@@ -125,14 +127,14 @@ BSC_COMPILATION_FLAGS += \
 
 # ================================================================
 # Search path for bsc for .bsv files
-COREDIR ?= $(REPO)
-COREW_DIRS = $(COREDIR)/src_Core/Core:$(COREDIR)/src_Core/CPU:$(COREDIR)/src_Core/ISA:$(COREDIR)/src_Core/PLIC:$(COREDIR)/src_Core/Debug_Module:$(COREDIR)/src_Core/BSV_Additional_Libs:$(COREDIR)/src_Core/RISCY_OOO/procs/RV64G_OOO:$(COREDIR)/src_Core/RISCY_OOO/procs/lib:$(COREDIR)/src_Core/RISCY_OOO/coherence/src:$(COREDIR)/src_Core/RISCY_OOO/fpgautils/lib
-WINDCOREIFCDIR ?= $(COREDIR)/libs/WindCoreInterface
-CHERICAPLIBDIR ?= $(COREDIR)/libs/cheri-cap-lib
-TAGCONTROLLERDIR ?= $(COREDIR)/libs/TagController
-RISCVHPMEVENTSDIR ?= $(COREDIR)/libs/RISCV_HPM_Events
-TAGCONTROLLER_DIRS = $(TAGCONTROLLERDIR)/TagController:$(TAGCONTROLLERDIR)/TagController/CacheCore
-BLUESTUFFDIR ?= $(COREDIR)/libs/BlueStuff
+CORE_DIR ?= $(REPO)
+COREW_DIRS = $(CORE_DIR)/src_Core/Core:$(CORE_DIR)/src_Core/CPU:$(CORE_DIR)/src_Core/ISA:$(CORE_DIR)/src_Core/PLIC:$(CORE_DIR)/src_Core/Debug_Module:$(CORE_DIR)/src_Core/BSV_Additional_Libs:$(CORE_DIR)/src_Core/RISCY_OOO/procs/RV64G_OOO:$(CORE_DIR)/src_Core/RISCY_OOO/procs/lib:$(CORE_DIR)/src_Core/RISCY_OOO/coherence/src:$(CORE_DIR)/src_Core/RISCY_OOO/fpgautils/lib
+WINDCORE_IFC_DIR ?= $(CORE_DIR)/libs/WindCoreInterface
+CHERICAPLIB_DIR ?= $(CORE_DIR)/libs/cheri-cap-lib
+TAG_CONTROLLER_DIR ?= $(CORE_DIR)/libs/TagController
+RISCV_HPM_EVENTS_DIR ?= $(CORE_DIR)/libs/RISCV_HPM_Events
+TAG_CONTROLLER_DIRS = $(TAG_CONTROLLER_DIR)/TagController:$(TAG_CONTROLLER_DIR)/TagController/CacheCore
+BLUESTUFFDIR ?= $(CORE_DIR)/libs/BlueStuff
 include $(BLUESTUFFDIR)/bluestuff.inc.mk # sets the BLUESTUFF_DIRS variable
 
 # search path for bsc imports
@@ -143,5 +145,5 @@ BSC_CONTRIB_LIB_DIR = %/Libraries
 endif
 BSC_CONTRIB_DIRS = $(BSC_CONTRIB_LIB_DIR)/Bus
 
-BSVPATH = +:$(BSC_CONTRIB_DIRS):$(WINDCOREIFCDIR):$(RISCVHPMEVENTSDIR):$(CHERICAPLIBDIR):$(TAGCONTROLLER_DIRS):$(COREW_DIRS):$(BLUESTUFF_DIRS)
+BSVPATH = +:$(BSC_CONTRIB_DIRS):$(WINDCORE_IFC_DIR):$(RISCV_HPM_EVENTS_DIR):$(CHERICAPLIB_DIR):$(TAG_CONTROLLER_DIRS):$(COREW_DIRS):$(BLUESTUFF_DIRS)
 BSC_PATH = -p $(BSVPATH)

--- a/builds/Resources/Include_RISCY_Config.mk
+++ b/builds/Resources/Include_RISCY_Config.mk
@@ -21,7 +21,7 @@ USE_XILINX_FPU ?= false
 # default 1 core
 CORE_NUM ?= 1
 # TSO or WEAK
-TSO_MM ?= false
+TSO_MM ?= true
 # Lr upgrades line to E (no forward progress guarantee)
 LR_UP_TO_E ?= false
 # Forbid LLC from respoding a load (toS) request with E state
@@ -98,7 +98,18 @@ BSC_COMPILATION_FLAGS += \
 	-D INSTR_PREFETCHER_IN_$(INSTR_PREFETCHER_LOCATION) \
 	-D INSTR_PREFETCHER_$(INSTR_PREFETCHER_TYPE) \
 	-D DATA_PREFETCHER_IN_$(DATA_PREFETCHER_LOCATION) \
-	-D DATA_PREFETCHER_$(DATA_PREFETCHER_TYPE)
+	-D DATA_PREFETCHER_$(DATA_PREFETCHER_TYPE) \
+	-D CAP128 \
+	-D MEM512 \
+	-D RISCV \
+	-D TSO_MM \
+	-D RV64 \
+	-D ISA_PRIV_M  -D ISA_PRIV_S  -D ISA_PRIV_U  \
+	-D SV39 \
+	-D ISA_I  -D ISA_M  -D ISA_A  -D ISA_F  -D ISA_D  -D ISA_FD_DIV  -D ISA_C  \
+	-D CheriBusBytes=64 \
+	-D CheriMasterIDWidth=1 \
+	-D CheriTransactionIDWidth=6
 
 # TODO:
 #    -D SELF_INV_CACHE -D L1D_MAX_HITS=$(SELF_INV_CACHE)
@@ -111,3 +122,26 @@ BSC_COMPILATION_FLAGS += \
 # +RTS -K1G -RTS " --bscflags=" -steps-max-intervals 200  -check-assert
 
 # ================================================================
+
+# ================================================================
+# Search path for bsc for .bsv files
+COREDIR ?= $(REPO)
+COREW_DIRS = $(COREDIR)/src_Core/Core:$(COREDIR)/src_Core/CPU:$(COREDIR)/src_Core/ISA:$(COREDIR)/src_Core/PLIC:$(COREDIR)/src_Core/Debug_Module:$(COREDIR)/src_Core/BSV_Additional_Libs:$(COREDIR)/src_Core/RISCY_OOO/procs/RV64G_OOO:$(COREDIR)/src_Core/RISCY_OOO/procs/lib:$(COREDIR)/src_Core/RISCY_OOO/coherence/src:$(COREDIR)/src_Core/RISCY_OOO/fpgautils/lib
+WINDCOREIFCDIR ?= $(COREDIR)/libs/WindCoreInterface
+CHERICAPLIBDIR ?= $(COREDIR)/libs/cheri-cap-lib
+TAGCONTROLLERDIR ?= $(COREDIR)/libs/TagController
+RISCVHPMEVENTSDIR ?= $(COREDIR)/libs/RISCV_HPM_Events
+TAGCONTROLLER_DIRS = $(TAGCONTROLLERDIR)/TagController:$(TAGCONTROLLERDIR)/TagController/CacheCore
+BLUESTUFFDIR ?= $(COREDIR)/libs/BlueStuff
+include $(BLUESTUFFDIR)/bluestuff.inc.mk # sets the BLUESTUFF_DIRS variable
+
+# search path for bsc imports
+ifdef BSC_CONTRIB_DIR
+BSC_CONTRIB_LIB_DIR = $(BSC_CONTRIB_DIR)/lib/Libraries
+else
+BSC_CONTRIB_LIB_DIR = %/Libraries
+endif
+BSC_CONTRIB_DIRS = $(BSC_CONTRIB_LIB_DIR)/Bus
+
+BSVPATH = +:$(BSC_CONTRIB_DIRS):$(WINDCOREIFCDIR):$(RISCVHPMEVENTSDIR):$(CHERICAPLIBDIR):$(TAGCONTROLLER_DIRS):$(COREW_DIRS):$(BLUESTUFF_DIRS)
+BSC_PATH = -p $(BSVPATH)

--- a/builds/Resources/Include_bluesim.mk
+++ b/builds/Resources/Include_bluesim.mk
@@ -18,12 +18,12 @@ include .depends.mk
 # BSC_COMPILATION_FLAGS += -D RVFI
 
 .depends.mk: TagTableStructure.bsv StatCounters.bsv GenerateHPMVector.bsv | build_dir
-	if ! bluetcl -exec makedepend -elab -sim  $(TMP_DIRS)  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS)  -p $(BSC_PATH) -o $@ $(TOPFILE); then rm -f $@ && false; fi
+	if ! bluetcl -exec makedepend -elab -sim  $(TMP_DIRS)  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS)  $(BSC_PATH) -o $@ $(TOPFILE); then rm -f $@ && false; fi
 endif
 
 %.bo:
 	$(info building $@)
-	bsc -elab -sim  $(TMP_DIRS)  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS)  -p $(BSC_PATH) $<
+	bsc -elab -sim  $(TMP_DIRS)  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS)  $(BSC_PATH) $<
 
 .PHONY: compile
 compile: build_dir/Top_HW_Side.bo | build_dir

--- a/src_SSITH_P3/Makefile
+++ b/src_SSITH_P3/Makefile
@@ -78,17 +78,17 @@ src_BSV/TagTableStructure.bsv: $(REPO)/libs/TagController/tagsparams.py
 
 .PHONY: generate_hpm_vector
 generate_hpm_vector: GenerateHPMVector.bsv
-GenerateHPMVector.bsv: $(RISCVHPMEVENTSDIR)/parse_counters.py
+GenerateHPMVector.bsv: $(RISCV_HPM_EVENTS_DIR)/parse_counters.py
 	@echo "INFO: Re-generating GenerateHPMVector bluespec file"
-	$^ $(RISCVHPMEVENTSDIR)/counters.yaml -m ProcTypes -b $@
+	$^ $(RISCV_HPM_EVENTS_DIR)/counters.yaml -m ProcTypes -b $@
 	@echo "INFO: Re-generated GenerateHPMVector bluespec file"
 
 
 .PHONY: stat_counters
 stat_counters: StatCounters.bsv
-StatCounters.bsv: $(RISCVHPMEVENTSDIR)/parse_counters.py
+StatCounters.bsv: $(RISCV_HPM_EVENTS_DIR)/parse_counters.py
 	@echo "INFO: Re-generating HPM events struct bluepsec file"
-	$^ $(RISCVHPMEVENTSDIR)/counters.yaml -m ProcTypes -s $@
+	$^ $(RISCV_HPM_EVENTS_DIR)/counters.yaml -m ProcTypes -s $@
 	@echo "INFO: Re-generated HPM events struct bluespec file"
 compile_sim: tagsparams stat_counters generate_hpm_vector
 compile_synth: tagsparams stat_counters generate_hpm_vector

--- a/src_SSITH_P3/Makefile
+++ b/src_SSITH_P3/Makefile
@@ -19,26 +19,19 @@ compile: compile_sim compile_synth
 REPO ?= $(CURDIR)/..
 ARCH ?= RV64ACDFIMSUxCHERI
 
+# Set number of cores for RISCY config
+CORE_NUM = 2
+
+# Set X and Y
+include $(REPO)/builds/Resources/Include_RISCY_Config.mk
+
 # ================================================================
 # RISC-V config macros passed into Bluespec 'bsc' compiler
 
 BSC_COMPILATION_FLAGS += \
-	-D RV64 \
-	-D ISA_PRIV_M  -D ISA_PRIV_S  -D ISA_PRIV_U  \
-	-D SV39 \
-	-D ISA_I  -D ISA_M  -D ISA_A  -D ISA_F  -D ISA_D  -D ISA_FD_DIV  -D ISA_C  \
-	-D CheriBusBytes=64 \
-	-D CheriMasterIDWidth=1 \
-	-D CheriTransactionIDWidth=6 \
 	-D PERFORMANCE_MONITORING \
-	-D SHIFT_BARREL    \
-	-D MULT_SERIAL    \
 	-D Near_Mem_Caches    \
 	-D FABRIC64    \
-	-D CAP128 \
-	-D MEM512 \
-	-D RISCV \
-	-D TSO_MM \
 	-D INCLUDE_GDB_CONTROL \
 	-D BRVF_TRACE \
 	-D XILINX_BSCAN  -D JTAG_TAP
@@ -52,36 +45,6 @@ SYNTH_BSC_OPTIONS = -D XILINX_XCVU9P
 
 # Sim only BSC_COMPILATION_FLAGS
 SIM_BSC_OPTIONS = -D BSIM
-
-# Set number of cores for RISCY config
-CORE_NUM = 2
-
-# Only used if we don't have INCLUDE_GDB_CONTROL
-#	-D EXTERNAL_DEBUG_MODULE
-
-include $(REPO)/builds/Resources/Include_RISCY_Config.mk
-
-# ================================================================
-# Search path for bsc for .bsv files
-COREDIR ?= $(REPO)
-COREW_DIRS = $(CURDIR)/src_BSV:$(COREDIR)/src_Core/Core:$(COREDIR)/src_Core/CPU:$(COREDIR)/src_Core/ISA:$(COREDIR)/src_Core/PLIC:$(COREDIR)/src_Core/Debug_Module:$(COREDIR)/src_Core/BSV_Additional_Libs:$(COREDIR)/src_Core/RISCY_OOO/procs/RV64G_OOO:$(COREDIR)/src_Core/RISCY_OOO/procs/lib:$(COREDIR)/src_Core/RISCY_OOO/coherence/src:$(COREDIR)/src_Core/RISCY_OOO/fpgautils/lib
-WINDCOREIFCDIR ?= $(COREDIR)/libs/WindCoreInterface
-CHERICAPLIBDIR ?= $(COREDIR)/libs/cheri-cap-lib
-TAGCONTROLLERDIR ?= $(COREDIR)/libs/TagController
-RISCVHPMEVENTSDIR ?= $(COREDIR)/libs/RISCV_HPM_Events
-TAGCONTROLLER_DIRS = $(TAGCONTROLLERDIR)/TagController:$(TAGCONTROLLERDIR)/TagController/CacheCore
-BLUESTUFFDIR ?= $(COREDIR)/libs/BlueStuff
-include $(BLUESTUFFDIR)/bluestuff.inc.mk # sets the BLUESTUFF_DIRS variable
-
-# search path for bsc imports
-ifdef BSC_CONTRIB_DIR
-BSC_CONTRIB_LIB_DIR = $(BSC_CONTRIB_DIR)/lib/Libraries
-else
-BSC_CONTRIB_LIB_DIR = %/Libraries
-endif
-BSC_CONTRIB_DIRS = $(BSC_CONTRIB_LIB_DIR)/Bus
-BSVPATH = +:$(BSC_CONTRIB_DIRS):$(WINDCOREIFCDIR):$(RISCVHPMEVENTSDIR):$(CHERICAPLIBDIR):$(TAGCONTROLLER_DIRS):$(COREW_DIRS):$(BLUESTUFF_DIRS)
-BSC_PATH = -p $(BSVPATH)
 
 # ----------------
 # Top-level file and module
@@ -151,13 +114,13 @@ Verilog_RTL_sim:
 .PHONY: compile_synth
 compile_synth: | build_dir_synth Verilog_RTL
 	@echo  "INFO: Generating RTL into Verilog_RTL for synthesis ..."
-	bsc -u -elab -verilog  -vdir Verilog_RTL $(BUILD_DIRS_SYNTH)  $(BSC_COMPILATION_FLAGS)  $(SYNTH_BSC_OPTIONS) $(BSC_PATH)  $(TOPFILE)
+	bsc -u -elab -verilog  -vdir Verilog_RTL $(BUILD_DIRS_SYNTH)  $(BSC_COMPILATION_FLAGS)  $(SYNTH_BSC_OPTIONS) $(BSC_PATH) -p +:src_BSV $(TOPFILE)
 	@echo  "INFO: Generated Synth RTL into Verilog_RTL"
 
 .PHONY: compile_sim
 compile_sim: | build_dir_sim Verilog_RTL_sim
 	@echo  "INFO: Generating RTL into Verilog_RTL_sim for simulation ..."
-	bsc -u -elab -verilog  -vdir Verilog_RTL_sim $(BUILD_DIRS_SIM)  $(BSC_COMPILATION_FLAGS) $(SIM_BSC_OPTIONS) $(BSC_PATH)  $(TOPFILE)
+	bsc -u -elab -verilog  -vdir Verilog_RTL_sim $(BUILD_DIRS_SIM)  $(BSC_COMPILATION_FLAGS) $(SIM_BSC_OPTIONS) $(BSC_PATH) -p +:src_BSV $(TOPFILE)
 
 # ================================================================
 


### PR DESCRIPTION
are in Include_RISCY_Config.mk so that this can be included from an external repo without replicating Toooba branch-specific flags in that repo.

Specifically, this allows the DE10Pro-cheri-bgas makefile to be build with a variety of Toooba subrepos without modifying its own makefile.  This also allows the build directories and src_SSITH_P3 directories to share much more of their flags and dependencies than before, which has been a source of confusion and extra work in the past.