### PR TITLE
Move RVFI toggle into Include_RISCY_Config.mk

### DIFF
--- a/builds/RV64ACDFIMSUxCHERI_Toooba_RVFI_DII_bluesim/Makefile
+++ b/builds/RV64ACDFIMSUxCHERI_Toooba_RVFI_DII_bluesim/Makefile
@@ -3,7 +3,7 @@
 # ================================================================
 # Path to RISCY-OOO sources not included in Common
 
-EXTRA_DIRS = $(RISCY_HOME)/../../src_Verifier:$(RISCY_HOME)/../../src_Verifier/BSV-RVFI-DII
+EXTRA_DIRS = $(RISCY_HOME)/../../src_Verifier
 
 # ================================================================
 
@@ -13,9 +13,12 @@ ARCH ?= RV64ACDFIMSUxCHERI
 # ================================================================
 # RISC-V config macros passed into Bluespec 'bsc' compiler
 
+# "-D RVFI" is set by Include_RISCY_Config
+# "-D RVFI_DII" enables injecting insructions, not just logging them,
+# and requires the EXTRA_DIRS set above
+
 BSC_COMPILATION_FLAGS += \
 	-D RVFI_DII \
-	-D RVFI \
 	-D CONTRACTS_VERIFY \
 
 # Default ISA test
@@ -23,16 +26,17 @@ BSC_COMPILATION_FLAGS += \
 TEST ?= rv64ui-p-add
 
 #================================================================
+# Parameter settings for MIT RISCY, setup paths etc. for Include_Common
+
+CACHE_SIZE ?= TEST
+RVFI = true
+
+include $(REPO)/builds/Resources/Include_RISCY_Config.mk
+
+#================================================================
 # Common boilerplate rules
 
 include $(REPO)/builds/Resources/Include_Common.mk
-
-#================================================================
-# Parameter settings for MIT RISCY
-
-CACHE_SIZE ?= TEST
-
-include $(REPO)/builds/Resources/Include_RISCY_Config.mk
 
 #================================================================
 # Makefile rules for building for specific simulator: bluesim

--- a/builds/RV64ACDFIMSUxCHERI_Toooba_RVFI_DII_verilator/Makefile
+++ b/builds/RV64ACDFIMSUxCHERI_Toooba_RVFI_DII_verilator/Makefile
@@ -3,7 +3,7 @@
 # ================================================================
 # Path to RISCY-OOO sources not included in Common
 
-EXTRA_DIRS = $(RISCY_HOME)/../../src_Verifier:$(RISCY_HOME)/../../src_Verifier/BSV-RVFI-DII
+EXTRA_DIRS = $(RISCY_HOME)/../../src_Verifier
 
 # ================================================================
 
@@ -13,25 +13,29 @@ ARCH ?= RV64ACDFIMSUxCHERI
 # ================================================================
 # RISC-V config macros passed into Bluespec 'bsc' compiler
 
+# "-D RVFI" is set by Include_RISCY_Config
+# "-D RVFI_DII" enables injecting insructions, not just logging them,
+# and requires the EXTRA_DIRS set above
+
 BSC_COMPILATION_FLAGS += \
 	-D RVFI_DII \
-	-D RVFI \
 
 # Default ISA test
 
 TEST ?= rv64ui-p-add
 
 #================================================================
+# Parameter settings for MIT RISCY, setup paths etc. for Include_Common
+
+CACHE_SIZE ?= TEST
+RVFI = true
+
+include $(REPO)/builds/Resources/Include_RISCY_Config.mk
+
+#================================================================
 # Common boilerplate rules
 
 include $(REPO)/builds/Resources/Include_Common.mk
-
-#================================================================
-# Parameter settings for MIT RISCY
-
-CACHE_SIZE ?= TEST
-
-include $(REPO)/builds/Resources/Include_RISCY_Config.mk
 
 #================================================================
 # Makefile rules for building for specific simulator: verilator

--- a/builds/RV64ACDFIMSUxCHERI_Toooba_bluesim/Makefile
+++ b/builds/RV64ACDFIMSUxCHERI_Toooba_bluesim/Makefile
@@ -4,11 +4,6 @@ REPO ?= ../..
 ARCH ?= RV64ACDFIMSUxCHERI
 
 # ================================================================
-# Path to RISCY-OOO sources not included in Common
-
-EXTRA_DIRS = $(REPO)/src_Verifier:$(REPO)/src_Verifier/BSV-RVFI-DII
-
-# ================================================================
 # RISC-V config macros passed into Bluespec 'bsc' compiler
 
 # Default ISA test
@@ -16,7 +11,7 @@ EXTRA_DIRS = $(REPO)/src_Verifier:$(REPO)/src_Verifier/BSV-RVFI-DII
 TEST ?= rv64ui-p-add
 
 #================================================================
-# Parameter settings for MIT RISCY
+# Parameter settings for MIT RISCY, setup paths etc. for Include_Common
 
 include $(REPO)/builds/Resources/Include_RISCY_Config.mk
 

--- a/builds/RV64ACDFIMSUxCHERI_Toooba_verilator/Makefile
+++ b/builds/RV64ACDFIMSUxCHERI_Toooba_verilator/Makefile
@@ -11,14 +11,14 @@ ARCH ?= RV64ACDFIMSUxCHERI
 TEST ?= rv64ui-p-add
 
 #================================================================
+# Parameter settings for MIT RISCY, setup paths etc. for Include_Common
+
+include $(REPO)/builds/Resources/Include_RISCY_Config.mk
+
+#================================================================
 # Common boilerplate rules
 
 include $(REPO)/builds/Resources/Include_Common.mk
-
-#================================================================
-# Parameter settings for MIT RISCY
-
-include $(REPO)/builds/Resources/Include_RISCY_Config.mk
 
 #================================================================
 # Makefile rules for building for specific simulator: verilator

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -62,7 +62,7 @@ BSC_COMPILATION_FLAGS += \
 	-promote-warnings T0054 \
 	+RTS -K128M -RTS  -show-range-conflict -show-schedule
 
-#	-D NO_SPEC_TRAINING -D NO_SPEC_REDIRECT -D NO_SPEC_STRAIGHT_PATH -D SPEC_RSB_FIXUP -D NO_SPEC_RSB_PUSH -D NO_SPEC_STL -D RVFI
+#	-D NO_SPEC_TRAINING -D NO_SPEC_REDIRECT -D NO_SPEC_STRAIGHT_PATH -D SPEC_RSB_FIXUP -D NO_SPEC_RSB_PUSH -D NO_SPEC_STL
 
 # ================================================================
 # Runs simulation executable on ELF given by EXAMPLE

--- a/builds/Resources/Include_RISCY_Config.mk
+++ b/builds/Resources/Include_RISCY_Config.mk
@@ -18,6 +18,14 @@ SIM_DRAM_TYPE := AWSF1
 # use Xilinx FPU IP cores
 USE_XILINX_FPU ?= false
 
+# default to not including RVFI at all.
+# setting this to true enables debug-displaying of executed instructions using the RVFI trace format. See Core.bsv.
+RVFI ?= false
+# Adding "-D RVFI_DII", linking $(CORE_DIR)/src_Verifier/BSV-RVFI-DII/SocketPacketUtils/socket_packet_utils.c
+# into simulation, and adding $(CORE_DIR)/src_Verifier to the include path allows injecting instructions
+# *and* retrieving those RVFI traces over a socket, which is used for TestRIG. See <https://github.com/CTSRD-CHERI/TestRIG/blob/master/RVFI-DII.md>.
+# See the builds/*_RVFI_DII_*/ Makefiles.
+
 # default 1 core
 CORE_NUM ?= 1
 # TSO or WEAK
@@ -119,7 +127,7 @@ BSC_COMPILATION_FLAGS += \
 #    -D NO_LOAD_RESP_E
 # various SECURITY related flags
 #    -D PERF_COUNT    -D CHECK_DEADLOCK    -D RENAME_DEBUG ...
-#    -D NO_SPEC_RSB_PUSH -D NO_SPEC_STL -D RVFI
+#    -D NO_SPEC_RSB_PUSH -D NO_SPEC_STL
 
 # +RTS -K1G -RTS " --bscflags=" -steps-max-intervals 200  -check-assert
 
@@ -145,5 +153,10 @@ BSC_CONTRIB_LIB_DIR = %/Libraries
 endif
 BSC_CONTRIB_DIRS = $(BSC_CONTRIB_LIB_DIR)/Bus
 
-BSVPATH = +:$(BSC_CONTRIB_DIRS):$(WINDCORE_IFC_DIR):$(RISCV_HPM_EVENTS_DIR):$(CHERICAPLIB_DIR):$(TAG_CONTROLLER_DIRS):$(COREW_DIRS):$(BLUESTUFF_DIRS)
-BSC_PATH = -p $(BSVPATH)
+BSC_PATH += -p +:$(BSC_CONTRIB_DIRS):$(WINDCORE_IFC_DIR):$(RISCV_HPM_EVENTS_DIR):$(CHERICAPLIB_DIR):$(TAG_CONTROLLER_DIRS):$(COREW_DIRS):$(BLUESTUFF_DIRS)
+
+ifeq ($(RVFI),true)
+BSC_COMPILATION_FLAGS += \
+	-D RVFI
+BSC_PATH += -p +:$(CORE_DIR)/src_Verifier/BSV-RVFI-DII
+endif

--- a/builds/Resources/Include_bluesim.mk
+++ b/builds/Resources/Include_bluesim.mk
@@ -15,8 +15,6 @@ build_dir:
 ifeq (,$(filter clean full_clean,$(MAKECMDGOALS)))
 include .depends.mk
 
-# BSC_COMPILATION_FLAGS += -D RVFI
-
 .depends.mk: TagTableStructure.bsv StatCounters.bsv GenerateHPMVector.bsv | build_dir
 	if ! bluetcl -exec makedepend -elab -sim  $(TMP_DIRS)  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS)  $(BSC_PATH) -o $@ $(TOPFILE); then rm -f $@ && false; fi
 endif
@@ -40,8 +38,8 @@ BSC_C_FLAGS += \
 	-Xl -v \
 	-Xc -O1 -Xc++ -O1 \
 
-BSC_COMPILATION_FLAGS += \
-        -D RVFI
+# socket_packet_utils.c is only necessary if RVFI_DII is defined, as it's the bridge that allows 
+# RVFI injection/trace retrieval, but we can compile+link it no matter what.
 
 # For Bluespec_2019.05.beta2-debian9stretch-amd64
 # you may have to remove the line: -Xc++ -D_GLIBCXX_USE_CXX11_ABI=0

--- a/builds/Resources/Include_verilator.mk
+++ b/builds/Resources/Include_verilator.mk
@@ -19,19 +19,19 @@ ifeq (,$(filter clean full_clean,$(MAKECMDGOALS)))
 include .depends.mk
 
 .depends.mk: TagTableStructure.bsv StatCounters.bsv GenerateHPMVector.bsv | build_dir Verilog_RTL
-	if ! bluetcl -exec makedepend -verilog -elab  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS) -p $(BSC_PATH) -o $@ $(TOPFILE); then rm -f $@ && false; fi
+	if ! bluetcl -exec makedepend -verilog -elab  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS) $(BSC_PATH) -o $@ $(TOPFILE); then rm -f $@ && false; fi
 endif
 
 %.bo:
 	$(info building $@)
-	bsc -verilog -elab  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS) -p $(BSC_PATH) $<
+	bsc -verilog -elab  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS) $(BSC_PATH) $<
 
 .PHONY: compile
 compile: build_dir/Top_HW_Side.bo | build_dir Verilog_RTL
 #Verilog_RTL/mkTop_HW_Side.v:  build_dir Verilog_RTL /tmp/src_dir $(VERILOG_SUB_MODULES)
 #Verilog_RTL/mkTop_HW_Side.v: $(TOPFILE) build_dir/Top_HW_Side.bo build_dir Verilog_RTL
 #	@echo  "INFO: Verilog RTL generation ..."
-#	bsc -u -verilog  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS) -p $(BSC_PATH) $<
+#	bsc -u -verilog  $(RTL_GEN_DIRS)  $(BSC_COMPILATION_FLAGS) $(BSC_PATH) $<
 #	@echo  "INFO: Verilog RTL generation finished"
 
 # ================================================================
@@ -62,6 +62,9 @@ VERILATOR_FLAGS += -Wfuture-DEPRECATED
 
 VTOP                = V$(TOPMODULE)_edited
 VERILATOR_RESOURCES = $(REPO)/builds/Resources/Verilator_resources
+
+# socket_packet_utils.c is only necessary if RVFI_DII is defined, as it's the bridge that allows 
+# RVFI injection/trace retrieval, but we can compile+link it no matter what.
 
 .PHONY: simulator
 simulator: build_dir/Top_HW_Side.bo


### PR DESCRIPTION
Previously, Makefiles had to add new include paths and -D defines manually when they wanted to include RVFI. This caused hard-to-diagnose errors in repositories consuming Toooba that expected -D RVFI to work. This commit makes Include_RISCY_Config.mk take an optional make-variable argument RVFI, which defaults to "false", and adds the relevant paths and -D defines if it is set to "true". This does not cover RVFI_DII, which is a simulation-only extension to allow instruction injection. This commit also includes fixes to the Makefiles in ./builds/ to use this interface properly.