### PR TITLE
Clear compressed and uncompressed BTBs on mispred

### DIFF
--- a/src_Core/RISCY_OOO/procs/lib/Btb.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Btb.bsv
@@ -120,10 +120,11 @@ module mkBtbCore(NextAddrPred#(hashSz))
                   pc, getBank(pc), taken, nextPc, $time);*/
         CompressedTarget shortMask = -1;
         CapMem mask = ~zeroExtend(shortMask);
-        if ((pc&mask) == (nextPc&mask))
-            compressedRecords[getBank(pc)].update(lookupKey(pc), VnD{v:taken, d:truncate(nextPc)});
-        else
-            fullRecords[getBank(pc)].update(lookupKey(pc), VnD{v:taken, d:nextPc});
+        let compressable = (pc&mask) == (nextPc&mask);
+        if (compressable || !taken)
+            compressedRecords[getBank(pc)].updateMayInsert(lookupKey(pc), VnD{v:taken, d:truncate(nextPc)}, taken);
+        if (!compressable || !taken)
+            fullRecords[getBank(pc)].updateMayInsert(lookupKey(pc), VnD{v:taken, d:nextPc}, taken);
     endrule
 
     method Action put_pc(CapMem pc);


### PR DESCRIPTION
This fixes a wedge in the frontend: the fetch stage could get stuck in a loop, with the next address predictor deciding that the redirect PC is a compressed instruction doing a close jump. On mispredict, this would get retrained, but "mispedict" was denoted as an untaken branch to PC+2. If unlucky, PC+2 could cross an alignment boundary, causing the untaken branch to be interpreted as a long branch, leaving an old competing entry in the compressed branch BTB, which would then take priority.
Fix by always marking entries in both close and long BTBs when not taken: to avoid hurting performance, this kind of update will not insert into either BTB unless already present.