### PR TITLE
Rearrange to remove warnings and errors

### DIFF
--- a/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
@@ -31,10 +31,10 @@ interface RWBramCore#(type addrT, type dataT);
     method Action deqRdResp;
 endinterface
 
-module mkRWBramCoreUGLoaded#(String fileName)(RWBramCore#(addrT, dataT)) provisos(
+module mkRWBramCoreUGLoaded(RWBramCore#(addrT, dataT)) provisos(
     Bits#(addrT, addrSz), Bits#(dataT, dataSz)
 );
-    BRAM_DUAL_PORT#(addrT, dataT) bram <- mkBRAMCore2Load(valueOf(TExp#(addrSz)), False, fileName, False);
+    BRAM_DUAL_PORT#(addrT, dataT) bram <- mkBRAMCore2(valueOf(TExp#(addrSz)), False);
     BRAM_PORT#(addrT, dataT) wrPort = bram.a;
     BRAM_PORT#(addrT, dataT) rdPort = bram.b;
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -661,7 +661,6 @@ module mkFetchStage(FetchStage);
    Vector#(SupSize,Integer) indices = genVector;
 
    rule doDecode(f2d.deqS[0].canDeq && isCurrent(f2d.deqS[0].first)/*( && all(isCurrentOrEmptyPred, indices)*/);
-      virtualReg <= False;
       Vector#(SupSize, Maybe#(InstrFromFetch2)) decodeIn = replicate(Invalid);
       // Express the incoming fragments as a vector of maybes.
       Vector#(SupSizeX2, Maybe#(Fetch2ToDecode)) frags;

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -748,7 +748,7 @@ module mkFetchStage(FetchStage);
                 dir_pred.taken = unpack(took);
 
                 if(in.predicted_branch) begin
-                    let recieved <- dirPred.pred[branchCountRecieved].pred; 
+                    let recieved <- dirPred.pred[i].pred; 
                     $display("DECODE DEQUEUE on %x ", pc, fshow(decode_result.dInst.iType), "\n");
                     
                     if(decode_result.dInst.iType == Br && !likely_epoch_change) begin
@@ -781,7 +781,6 @@ module mkFetchStage(FetchStage);
                     dir_spec = unpack(0);
                 end
 
-               
                doAssert(in.main_epoch == f_main_epoch, "main epoch must match");
 
                let decode_result = decode(in.inst);    // Decode 32b inst, or 32b expansion of 16b inst

--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -27,7 +27,7 @@ import EpochManager::*;
 import Vector::*;
 import Fifos::*;
 
-(* noinline *)
+//(* noinline *)
 function Maybe#(Addr) decodeBrPred( Addr pc, DecodedInst dInst, Bool histTaken, Bool is_32b_inst);
   Addr pcPlusN = pc + (is_32b_inst ? 4 : 2);
   Data imm_val = fromMaybe(?, getDInstImm(dInst));
@@ -98,7 +98,7 @@ interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT); /
     // the current main_epoch and decode.epoch each cycle, also every predictor will need this added logic, sounds like a pain
     interface Vector#(SupSize, SupFifoDeq#(GuardedResult#(DirPredResult#(trainInfoT)))) clearIfc;
 
-    method specInfoT getSpec(SupCnt i);
+    method Vector#(SupSizeX2, specInfoT) getSpec(Bit#(SupSizeX2) mask);
     method Action updateSpec(Bit#(TAdd#(TLog#(SupSizeX2),1)) i);
 
     method Action flush;

--- a/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
@@ -75,7 +75,7 @@ typedef TageTestFastTrainInfo DirPredFastTrainInfo;
 `endif
 
 typedef PredIn#(DirPredFastTrainInfo) DirPredIn;
-//(* synthesize *)
+(* synthesize *)
 module mkDirPredictor(DirPredictor#(DirPredTrainInfo, DirPredSpecInfo, DirPredFastTrainInfo));
 `ifdef DIR_PRED_BHT
 `ifdef SECURITY

--- a/src_Core/RISCY_OOO/procs/lib/Tage.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Tage.bsv
@@ -456,7 +456,7 @@ module mkTage(Tage#(numTables)) provisos(
                 global.updateRecoveredHistory(pack(specUpdate.taken));
 
             `ifdef DEBUG_TAGETEST   
-                $display("TAGETEST Recovery by %d Misprediction on %d, cycle %d %d\n", numBits, specInfo.ooIndex, cur_cycle, nonBranch);
+                $display("TAGETEST Recovery by %d Misprediction on %d, cycle %d %d\n", numBits, specUpdate.specInfo.ooIndex, cur_cycle, specUpdate.nonBranch);
             `endif
             for (Integer i = 0; i < valueOf(numTables); i = i +1) begin
                 let tab = taggedTablesVector[i];

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -26,6 +26,7 @@ typedef TageSpecInfo TageTestSpecInfo;
 typedef TageFastTrainInfo TageTestFastTrainInfo;
 //typedef TagePred2ToPred3Data#(`NUM_TABLES) TageTestPred2ToPred3Info;
 
+(* synthesize *)
 module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo));
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -26,7 +26,6 @@ typedef TageSpecInfo TageTestSpecInfo;
 typedef TageFastTrainInfo TageTestFastTrainInfo;
 //typedef TagePred2ToPred3Data#(`NUM_TABLES) TageTestPred2ToPred3Info;
 
-(* synthesize *)
 module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo));
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -26,6 +26,7 @@ typedef TageSpecInfo TageTestSpecInfo;
 typedef TageFastTrainInfo TageTestFastTrainInfo;
 //typedef TagePred2ToPred3Data#(`NUM_TABLES) TageTestPred2ToPred3Info;
 
+(* synthesize *)
 module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo));
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;
@@ -63,8 +64,8 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageT
         tage.dirPredInterface.specRecover(specInfo, taken, nonBranch);
     endmethod
 
-    method TageSpecInfo getSpec(SupCnt i);
-        return tage.dirPredInterface.getSpec(i);
+    method Vector#(SupSizeX2, TageSpecInfo) getSpec(Bit#(SupSizeX2) mask);
+        return tage.dirPredInterface.getSpec(mask);
     endmethod
 
     method Action updateSpec(Bit#(TAdd#(TLog#(SupSizeX2),1)) i);

--- a/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
@@ -97,8 +97,8 @@ module mkTaggedTableBRAM#(GlobalBranchHistory#(GlobalHistoryLength) global) (Tag
     FoldedHistory#(TAdd#(tagSize, indexSize)) folded <- mkFoldedHistory(valueOf(historyLength), global);
     //RegFile#(Bit#(indexSize), TaggedTableEntry#(tagSize)) tab <- mkRegFileWCFLoad(regInitTaggedTableFilename, 0, maxBound);
 
-    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUGLoaded(regInitTaggedTableFilename));
-    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUGLoaded(regInitTaggedTableFilename));
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUGLoaded);
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUGLoaded);
 
     Vector#(SupSize, TaggedTableRead#(tagSize, indexSize)) taggedTableReadIfc;
 //    Reg#(Maybe#(Bit#(indexSize))) decrementReadFrom <- mkDReg(tagged Invalid);


### PR DESCRIPTION
- Remove (* no_inline *) from decodeBrPred function as I use it multiple times in fetch to train BTB. Though could alternatively restructure 

- Restructure TAGE slightly to remove some of the conflicts so the warnings aren't necessary anymore, less combinatorial paths

- Rather than a BRAMLoad just use normal BRAM as I don't think Verilog supports this (at least not when I compile)