### PR TITLE
Remove synthesis annotation

### DIFF
--- a/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/DirPredictor.bsv
@@ -75,7 +75,7 @@ typedef TageTestFastTrainInfo DirPredFastTrainInfo;
 `endif
 
 typedef PredIn#(DirPredFastTrainInfo) DirPredIn;
-(* synthesize *)
+//(* synthesize *)
 module mkDirPredictor(DirPredictor#(DirPredTrainInfo, DirPredSpecInfo, DirPredFastTrainInfo));
 `ifdef DIR_PRED_BHT
 `ifdef SECURITY

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -26,7 +26,7 @@ typedef TageSpecInfo TageTestSpecInfo;
 typedef TageFastTrainInfo TageTestFastTrainInfo;
 //typedef TagePred2ToPred3Data#(`NUM_TABLES) TageTestPred2ToPred3Info;
 
-(* synthesize *)
+//(* synthesize *)
 module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo));
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;


### PR DESCRIPTION
Removing the synthesize annotation seems to fix the issue before with 

tage.specRecover and tage.pred[i].pred being registered. I still do not know why the (* synthesize *) primitive causes them to be registered/have a cycle delay but this atleast does fix the issue and Verilator seems to run fine with this gone