### PR TITLE
Performance counters for mispredictions and early redirects

### DIFF
--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -636,6 +636,9 @@ module mkCore#(CoreId coreId)(Core);
         method setReconcileD = reconcile_d._write(True);
         method killAll = coreFix.killAll;
         method redirectPc = fetchStage.redirect;
+        method Action recover_spec(DirPredSpecInfo specInfo);
+            fetchStage.recover_spec(specInfo, False, True);
+        endmethod
         method setFetchWaitRedirect = fetchStage.setWaitRedirect;
 `ifdef INCLUDE_GDB_CONTROL
         method setFetchWaitFlush    = fetchStage.setWaitFlush;

--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -1074,7 +1074,10 @@ module mkCore#(CoreId coreId)(Core);
      Reg#(EventsCache) events_llc_reg <- mkRegU;
      rule report_events;
          EventsCore events = unpack(pack(commitStage.events));
-         events.evt_REDIRECT = zeroExtend(pack(fetchStage.redirect_evt));
+         FetchEvents fe = fetchStage.events;
+         events.evt_REDIRECT = zeroExtend(pack(fe.evt_REDIRECT));
+         events.evt_EARLY_REDIRECT = zeroExtend(pack(fe.evt_EARLY_REDIRECT));
+         events.evt_BRANCH_MISPREDICT = zeroExtend(pack(fe.branch_evts.evt_BRANCH_MISPREDICT));
          hpm_core_events[1] <= events;
      endrule
 

--- a/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/RWBramCore.bsv
@@ -31,10 +31,10 @@ interface RWBramCore#(type addrT, type dataT);
     method Action deqRdResp;
 endinterface
 
-module mkRWBramCoreUGLoaded(RWBramCore#(addrT, dataT)) provisos(
+module mkRWBramCoreUGLoaded#(String fileName)(RWBramCore#(addrT, dataT)) provisos(
     Bits#(addrT, addrSz), Bits#(dataT, dataSz)
 );
-    BRAM_DUAL_PORT#(addrT, dataT) bram <- mkBRAMCore2(valueOf(TExp#(addrSz)), False);
+BRAM_DUAL_PORT#(addrT, dataT) bram <- mkBRAMCore2Load(valueOf(TExp#(addrSz)), False, fileName, False);
     BRAM_PORT#(addrT, dataT) wrPort = bram.a;
     BRAM_PORT#(addrT, dataT) rdPort = bram.b;
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/RenameStage.bsv
@@ -372,7 +372,8 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
                                 lsqAtCommitNotified: False,
                                 nonMMIOStDone: False,
                                 epochIncremented: True, // we have incremented epoch
-                                spec_bits: specTagManager.currentSpecBits
+                                spec_bits: specTagManager.currentSpecBits,
+                                spec_info: dpSpec
                                };
         rob.enqPort[0].enq(y);
         // record if we issue an interrupt
@@ -565,7 +566,8 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
                                 lsqAtCommitNotified: False,
                                 nonMMIOStDone: False,
                                 epochIncremented: True, // system inst has incremented epoch
-                                spec_bits: spec_bits
+                                spec_bits: spec_bits,
+                                spec_info: dpSpec
                                };
         rob.enqPort[0].enq(y);
 
@@ -736,7 +738,8 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
                                 lsqAtCommitNotified: False,
                                 nonMMIOStDone: False,
                                 epochIncremented: False,
-                                spec_bits: spec_bits
+                                spec_bits: spec_bits,
+                                spec_info: x.dpSpec
                                };
         rob.enqPort[0].enq(y);
 
@@ -1089,7 +1092,8 @@ module mkRenameStage#(RenameInput inIfc)(RenameStage);
                                                 lsqAtCommitNotified: False,
                                                 nonMMIOStDone: False,
                                                 epochIncremented: False,
-                                                spec_bits: spec_bits
+                                                spec_bits: spec_bits,
+                                                spec_info: dpSpec
                                                };
                         rob.enqPort[i].enq(y);
 

--- a/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BrPred.bsv
@@ -101,6 +101,10 @@ interface DirPredictor#(type trainInfoT, type specInfoT, type fastTrainInfoT); /
     method Vector#(SupSizeX2, specInfoT) getSpec(Bit#(SupSizeX2) mask);
     method Action updateSpec(Bit#(TAdd#(TLog#(SupSizeX2),1)) i);
 
+    `ifdef PERFORMANCE_MONITORING
+    method BranchEvents events;
+    `endif
+
     method Action flush;
     method Bool flush_done;
 endinterface

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -1085,6 +1085,8 @@ typedef struct {
    SupCnt evt_REDIRECT;
    SupCnt evt_TRAP;
    SupCnt evt_BRANCH;
+   SupCnt evt_BRANCH_MISPREDICT;
+   SupCnt evt_EARLY_REDIRECT;
    SupCnt evt_JAL;
    SupCnt evt_JALR;
    SupCnt evt_AUIPC;
@@ -1114,11 +1116,23 @@ typedef struct {
 } EventsCore deriving (Bits, FShow);
 typedef TDiv#(SizeOf#(EventsCore),SizeOf#(SupCnt)) EventsCoreElements;
 
+typedef struct {
+  Bool evt_REDIRECT;
+  Bool evt_EARLY_REDIRECT;
+  BranchEvents branch_evts;
+} FetchEvents deriving (Bits, FShow);
+
+typedef struct {
+  Bool evt_BRANCH_MISPREDICT;
+} BranchEvents deriving (Bits, FShow);
+
 typedef Bit#(Report_Width) HpmRpt;
 typedef struct {
    HpmRpt evt_REDIRECT;
    HpmRpt evt_TRAP;
    HpmRpt evt_BRANCH;
+   HpmRpt evt_BRANCH_MISPREDICT;
+   HpmRpt evt_EARLY_REDIRECT;
    HpmRpt evt_JAL;
    HpmRpt evt_JALR;
    HpmRpt evt_AUIPC;

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -2,6 +2,7 @@ import BrPred::*;
 import RegFile::*;
 import LFSR::*;
 import Vector::*;
+import DReg :: *;
 
 import TaggedTable::*;
 import ProcTypes::*;
@@ -26,20 +27,32 @@ typedef TageSpecInfo TageTestSpecInfo;
 typedef TageFastTrainInfo TageTestFastTrainInfo;
 //typedef TagePred2ToPred3Data#(`NUM_TABLES) TageTestPred2ToPred3Info;
 
-//(* synthesize *)
+(* synthesize *)
 module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageTestFastTrainInfo));
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;
+
+    `ifdef DEBUG_TAGETEST
     Reg#(UInt#(64)) predCount <- mkReg(0);
     Reg#(UInt#(64)) misPredCount <- mkReg(0);
+    `endif
+
+    `ifdef PERFORMANCE_MONITORING
+    Reg#(Bool) mispredict <- mkDReg(False);
+    `endif
 
     method Action update(Bool taken, TageTrainInfo#(`NUM_TABLES) train, Bool mispred);
+        `ifdef DEBUG_TAGETEST
         if(train.confirmed) begin // Take account of this
             predCount <= predCount+1;
             if(mispred)
                 misPredCount <= misPredCount + 1;
         end
         $display("Cycle %0d, TAGETEST, predCount = %d, mispred Count = %d\n", cur_cycle, predCount, misPredCount);
+        `endif
+        `ifdef PERFORMANCE_MONITORING
+            mispredict <= mispred && train.confirmed;
+        `endif
         
         tage.dirPredInterface.update(taken, train, mispred);
     endmethod
@@ -50,6 +63,8 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageT
     /*method Action confirmPred(Bit#(SupSize) results, SupCnt count);
         tage.dirPredInterface.confirmPred(results, count);
     endmethod*/
+
+    method BranchEvents events = BranchEvents{evt_BRANCH_MISPREDICT: mispredict};
 
     method Action nextPc(Vector#(SupSize,Maybe#(PredIn#(TageFastTrainInfo))) next);
         tage.dirPredInterface.nextPc(next);

--- a/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TaggedTableBRAM.bsv
@@ -97,8 +97,13 @@ module mkTaggedTableBRAM#(GlobalBranchHistory#(GlobalHistoryLength) global) (Tag
     FoldedHistory#(TAdd#(tagSize, indexSize)) folded <- mkFoldedHistory(valueOf(historyLength), global);
     //RegFile#(Bit#(indexSize), TaggedTableEntry#(tagSize)) tab <- mkRegFileWCFLoad(regInitTaggedTableFilename, 0, maxBound);
 
-    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUGLoaded);
-    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUGLoaded);
+    `ifdef DEBUG_TAGETEST
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUGLoaded(regInitTaggedTableFilename));
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUGLoaded(regInitTaggedTableFilename));
+    `else
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), InternalTaggedEntry#(tagSize))) entryTabs <- replicateM(mkRWBramCoreUG);
+    Vector#(SupSize, RWBramCore#(Bit#(indexSize), UsefulCtr)) usefulTabs <- replicateM(mkRWBramCoreUG);
+    `endif
 
     Vector#(SupSize, TaggedTableRead#(tagSize, indexSize)) taggedTableReadIfc;
 //    Reg#(Maybe#(Bit#(indexSize))) decrementReadFrom <- mkDReg(tagged Invalid);


### PR DESCRIPTION
Add Performance counters for early redirects (redirects in fetch pipeline) and branch mispredictions