### PR TITLE
Prevent trap redirects

### DIFF
--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -344,6 +344,9 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
                 branchRedirectCount <= branchRedirectCount +1;
                 $display("Staged Tage, redirectCount = %d, cycle = %d\n", branchRedirectCount, cur_cycle);
             end
+            else begin
+                $display("Redirect ALU %x", x.controlFlow.pc);
+            end
             doAssert(isValid(x.spec_tag), "mispredicted branch must have spec tag");
             inIfc.redirect(x.controlFlow.nextPc, validValue(x.spec_tag), x.tag, exeToFin.spec_bits);
             // must be a branch, train branch predictor

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/AluExePipeline.bsv
@@ -189,6 +189,7 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
     // index to send bypass, ordering doesn't matter
     Integer exeSendBypassPort = 0;
     Integer finishSendBypassPort = 1;
+    Reg#(UInt#(64)) branchRedirectCount <- mkReg(0);
 
 `ifdef PERF_COUNT
     // performance counters
@@ -339,6 +340,10 @@ module mkAluExePipeline#(AluExeInput inIfc)(AluExePipeline);
         (* split *)
         if (x.controlFlow.mispredict) (* nosplit *) begin
             // wrong branch predictin, we must have spec tag
+            if(x.iType == Br) begin
+                branchRedirectCount <= branchRedirectCount +1;
+                $display("Staged Tage, redirectCount = %d, cycle = %d\n", branchRedirectCount, cur_cycle);
+            end
             doAssert(isValid(x.spec_tag), "mispredicted branch must have spec tag");
             inIfc.redirect(x.controlFlow.nextPc, validValue(x.spec_tag), x.tag, exeToFin.spec_bits);
             // must be a branch, train branch predictor

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/CommitStage.bsv
@@ -659,6 +659,7 @@ module mkCommitStage#(CommitInput inIfc)(CommitStage);
          let trap_updates <- csrf.trap(trap.trap, trap.pc, trap.addr, trap.orig_inst);
          redirectQ.enq(trap_updates.new_pc);
          specRecoverQ.enq(trap.spec_info);
+         $display("Redirect caused by trap on %x\n", trap.pc);
 
 `ifdef INCLUDE_TANDEM_VERIF
        fa_to_TV (way0, rg_serial_num,
@@ -695,6 +696,7 @@ module mkCommitStage#(CommitInput inIfc)(CommitStage);
         inIfc.killAll;
         redirectQ.enq(x.pc);
         specRecoverQ.enq(x.spec_info);
+        $display("Redirect caused by killed load on %x\n", x.pc);
         inIfc.incrementEpoch;
 
         // the killed Ld should have claimed phy reg, we should not commit it;
@@ -799,6 +801,7 @@ module mkCommitStage#(CommitInput inIfc)(CommitStage);
         end
         redirectQ.enq(next_pc);
         specRecoverQ.enq(x.spec_info);
+        $display("Redirect caused by system instruction on %x\n", x.pc);
 
 `ifdef INCLUDE_TANDEM_VERIF
         fa_to_TV (way0, rg_serial_num,
@@ -1118,7 +1121,7 @@ module mkCommitStage#(CommitInput inIfc)(CommitStage);
 
     rule pass_redirect;
         inIfc.redirectPc(redirectQ.first);
-        inIfc.recover_spec(specRecoverQ.first);
+        //inIfc.recover_spec(specRecoverQ.first);
         redirectQ.deq;
         specRecoverQ.deq;
     endrule

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -966,6 +966,12 @@ module mkFetchStage(FetchStage);
     (* fire_when_enabled, no_implicit_conditions *)
     rule doSpecRecover(isValid(decodeSpecRecover.wget) || isValid(aluSpecRecover.wget));
         SpecRecoverInfo update = fromMaybe(validValue(decodeSpecRecover.wget), aluSpecRecover.wget);
+        
+        if(isValid(aluSpecRecover.wget))
+            $display("TAGETEST Redirect ALU Cycle:%d\n", cur_cycle);
+        else
+            $display("TAGETEST Redirect Decode Cycle:%d\n", cur_cycle);
+
         dirPred.specRecover(update.specInfo, update.taken, update.nonBranch);
     endrule
 

--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -497,6 +497,11 @@ module mkFetchStage(FetchStage);
         end
 
         Vector#(SupSizeX2, DirPredSpecInfo) recoverInfo = dirPred.getSpec(mask);
+
+        for(Integer i = 0; i < valueOf(SupSizeX2) && fromInteger(i) <= posLastSupX2; i = i + 1) begin
+            $display("TAGETEST %x, ooIndex: %d, Fast predictions: %b %d\n",  pc + fromInteger(2*i) , recoverInfo[i] ,pack(fastPredictions[i].train), fastPredictions[i].taken);
+
+        end
         
         `ifdef DEBUG_TAGETEST
         $display("FETCH1 %x, Cycle: %d last inst: %d branch count: %d", pc, cur_cycle, posLastSupX2, count);
@@ -855,6 +860,7 @@ module mkFetchStage(FetchStage);
                      $display("DECODE NAP TRAIN %x\n", last_x16_pc);
                      `endif
                      if(decode_result.dInst.iType != Br) begin
+                        $display("Decode redirect non branch: %x\n", last_x16_pc);
                         trainNAP = Valid (TrainNAP {pc: last_x16_pc, nextPc: decode_pred_next_pc, branch: False});
                         recover = tagged Valid tuple3(dir_spec, False, True);
                      end

--- a/src_Core/RISCY_OOO/procs/lib/BranchParams.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/BranchParams.bsv
@@ -1,5 +1,5 @@
 typedef 256 GlobalHistoryLength;
-typedef 18 MaxSpecSize;
+typedef 30 MaxSpecSize;
 
 String dirGoldStandard  = "/home/katy/C++/Toooba/";
 

--- a/src_Core/RISCY_OOO/procs/lib/GlobalBranchHistory.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/GlobalBranchHistory.bsv
@@ -1,5 +1,3 @@
-// Simple global history
-// No speculative recovery or anything
 import BrPred::*;
 import BranchParams::*;
 import Vector::*;

--- a/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/TageTest.bsv
@@ -32,7 +32,7 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageT
     Reg#(Bool) starting <- mkReg(True);
     Tage#(7) tage <- mkTage;
 
-    `ifdef DEBUG_TAGETEST
+    `ifdef DEBUG_TAGE
     Reg#(UInt#(64)) predCount <- mkReg(0);
     Reg#(UInt#(64)) misPredCount <- mkReg(0);
     `endif
@@ -42,7 +42,7 @@ module mkTageTest(DirPredictor#(TageTrainInfo#(`NUM_TABLES), TageSpecInfo, TageT
     `endif
 
     method Action update(Bool taken, TageTrainInfo#(`NUM_TABLES) train, Bool mispred);
-        `ifdef DEBUG_TAGETEST
+        `ifdef DEBUG_TAGE
         if(train.confirmed) begin // Take account of this
             predCount <= predCount+1;
             if(mispred)


### PR DESCRIPTION
Noticed for a couple benchmarks there were many killed loads. I turn off history recovery after a trap, as this worked to solve the issue on these benchmarks