### PR TITLE
Removed xCCSRs

### DIFF
--- a/src_Core/CPU/CsrFile.bsv
+++ b/src_Core/CPU/CsrFile.bsv
@@ -538,7 +538,6 @@ module mkCsrFile #(Data hartid)(CsrFile);
     Reg#(Bit#(4)) mtval2_cause <- mkCsrReg(0);
     Reg#(Data) mtval2_csr = concatReg4 (readOnlyReg(44'b0), mtval2_type, readOnlyReg(12'b0), mtval2_cause);
     // Capability cause register
-    Reg#(Data) mccsr_csr <- mkReadOnlyReg(64'b11);
     Reg#(Data) mseccfg_csr <- mkReadOnlyReg(64'b1000);
     Reg#(Data) menvcfg_csr <- mkReadOnlyReg(64'h1 << 28);
     Reg#(Data) senvcfg_csr <- mkReadOnlyReg(64'h1 << 28);
@@ -659,7 +658,6 @@ module mkCsrFile #(Data hartid)(CsrFile);
     // Capability cause register
     Reg#(Bit#(1)) global_cap_load_gen_s_reg <- mkCsrReg(0);
     Reg#(Bit#(1)) global_cap_load_gen_u_reg <- mkCsrReg(0);
-    Reg#(Data) sccsr_csr = concatReg4 (readOnlyReg(60'b0), global_cap_load_gen_u_reg, global_cap_load_gen_s_reg, readOnlyReg(2'b11));
     // sip: restricted view of mip
     Reg#(Data) sip_csr = concatReg9(
         readOnlyReg(54'b0),
@@ -893,7 +891,6 @@ module mkCsrFile #(Data hartid)(CsrFile);
             csrAddrSTVAL2:     stval2_csr;
             csrAddrSIP:        sip_csr;
             csrAddrSATP:       satp_csr;
-            csrAddrSCCSR:      sccsr_csr;
             // Machine CSRs
             csrAddrMSTATUS:    mstatus_csr;
             csrAddrMISA:       misa_csr;
@@ -914,7 +911,6 @@ module mkCsrFile #(Data hartid)(CsrFile);
             csrAddrMARCHID:    marchid_csr;
             csrAddrMIMPID:     mimpid_csr;
             csrAddrMHARTID:    mhartid_csr;
-            csrAddrMCCSR:      mccsr_csr;
             csrAddrMSECCFG:    mseccfg_csr;
             csrAddrMENVCFG:    menvcfg_csr;
             csrAddrSENVCFG:    senvcfg_csr;

--- a/src_Core/RISCY_OOO/procs/lib/CSRs.bsvi
+++ b/src_Core/RISCY_OOO/procs/lib/CSRs.bsvi
@@ -8,7 +8,6 @@
 // user non-standard CSRs (TODO)
 `CSR(TERMINATE,  12'h800) // terminate (used to exit Linux)
 `CSR(STATS,      12'h801) // turn on/off perf counters
-// `CSR(UCCSR,      12'h8c0)
 // supervisor standard CSRs
 `CSR(SSTATUS,    12'h100)
 // no user trap handler, so no se/ideleg
@@ -22,7 +21,6 @@
 `CSR(STVAL2,     12'h14B)
 `CSR(SIP,        12'h144)
 `CSR(SATP,       12'h180) // it's still called sptbr in spike
-`CSR(SCCSR,      12'h9c0)
 // machine standard CSRs
 `CSR(MSTATUS,    12'h300)
 `CSR(MISA,       12'h301)
@@ -136,7 +134,6 @@
 `CSR(MARCHID,    12'hf12)
 `CSR(MIMPID,     12'hf13)
 `CSR(MHARTID,    12'hf14)
-`CSR(MCCSR,      12'hbc0)
 `CSR(MSECCFG,    12'h747)
 `CSR(MENVCFG,    12'h30a)
 `CSR(SENVCFG,    12'h10a)


### PR DESCRIPTION
The `xCCSR` registers are not part of the RISC-V CHERI draft