### PR TITLE
Fix compressed hint instructions

### DIFF
--- a/src_Core/CPU/CPU_Decode_C.bsv
+++ b/src_Core/CPU/CPU_Decode_C.bsv
@@ -793,8 +793,7 @@ function Tuple2 #(Bool, Instr) fv_decode_C_ADDI (MISA  misa,  Bit #(2)  xl, Bool
       Bool is_legal = ((misa.c == 1'b1)
                        && (op == opcode_C1)
                        && (funct3 == funct3_C_ADDI)
-                       && (rd_rs1 != 0)
-                       && (nzimm6 != 0));
+                       && (rd_rs1 != 0));
 
       Bit #(12) imm12 = signExtend (nzimm6);
       let       instr = mkInstr_I_type (imm12, rd_rs1, f3_ADDI, rd_rs1, op_OP_IMM);
@@ -988,7 +987,6 @@ function Tuple2 #(Bool, Instr) fv_decode_C_SRAI (MISA  misa,  Bit #(2)  xl, Bool
                        && (funct3 == funct3_C_SRAI)
                        && (funct2 == funct2_C_SRAI)
                        && (rd_rs1 != 0)
-                       && (shamt6 != 0)
                        && ((xl == misa_mxl_32) ? (shamt6_5 == 0) : True));
 
       Bit #(12) imm12 = (  (xl == misa_mxl_32)

--- a/src_Core/CPU/CPU_Decode_C.bsv
+++ b/src_Core/CPU/CPU_Decode_C.bsv
@@ -938,7 +938,6 @@ function Tuple2 #(Bool, Instr) fv_decode_C_SLLI (MISA  misa,  Bit #(2)  xl, Bool
                        && (op == opcode_C2)
                        && (funct3 == funct3_C_SLLI)
                        && (rd_rs1 != 0)
-                       && (shamt6 != 0)
                        && ((xl == misa_mxl_32) ? (imm_at_12 == 0) : True));
 
       Bit #(12) imm12 = (  (xl == misa_mxl_32)
@@ -964,7 +963,6 @@ function Tuple2 #(Bool, Instr) fv_decode_C_SRLI (MISA  misa,  Bit #(2)  xl, Bool
                        && (funct3 == funct3_C_SRLI)
                        && (funct2 == funct2_C_SRLI)
                        && (rd_rs1 != 0)
-                       && (shamt6 != 0)
                        && ((xl == misa_mxl_32) ? (shamt6_5 == 0) : True));
 
       Bit #(12) imm12 = (  (xl == misa_mxl_32)


### PR DESCRIPTION
Some of the compressed hint instructions raised exceptions, which is not in line with the specification.