### PR TITLE
Add zicond implementation

### DIFF
--- a/src_Core/RISCY_OOO/procs/lib/Decode.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Decode.bsv
@@ -503,7 +503,7 @@ function DecodeResult decode(Instruction inst, Bool cap_mode);
                     regs.src2 = mCapFunc matches tagged Valid .f &&& tpl_1(f) == CapModify(Move) ? Invalid : Valid(tagged Gpr (swap ? rs1 : rs2));
                 end
                 opCapBoundsZero: begin
-                    dInst.iType = Cap;
+                    legalInst = False;
                     Maybe#(CapFunc) mCapFunc = case (funct3)
                         fnEQZ: Valid(CapModify (CZeroEqz));
                         fnNEZ: Valid(CapModify (CZeroNez));
@@ -520,9 +520,8 @@ function DecodeResult decode(Instruction inst, Bool cap_mode);
                             fnNEZ: Valid (Nez);
                             default: Invalid;
                         endcase;
-                        legalInst = isValid(mAluFunc);
                         dInst.execFunc = tagged Alu mAluFunc.Valid;
-                        if(legalInst) dInst.iType = Alu;
+                        if(isValid(mAluFunc)) dInst.iType = Alu;
                     end
                     regs.dst = Valid(tagged Gpr rd);
                     regs.src1 = Valid(tagged Gpr rs1);

--- a/src_Core/RISCY_OOO/procs/lib/Decode.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Decode.bsv
@@ -428,6 +428,23 @@ function DecodeResult decode(Instruction inst, Bool cap_mode);
                     legalInst = isValid(mAluFunc);
                     dInst.execFunc = tagged Alu mAluFunc.Valid;
                 end
+                opCZERO: begin
+                    Maybe#(AluFunc) mAluFunc = case (funct3)
+                        fnEQZ: Valid (Eqz);
+                        fnNEZ: Valid (Nez);
+                        default: Invalid;
+                    endcase;
+                    legalInst = isValid(mAluFunc);
+                    dInst.execFunc = tagged Alu mAluFunc.Valid;
+                    if(cap_mode) begin
+                        dInst.iType = Cap;
+                        dInst.capFunc = case (funct3)
+                            fnEQZ: CapModify (CZeroEqz);
+                            fnNEZ: CapModify (CZeroNez);
+                            default: tagged Other;
+                        endcase;
+                    end
+                end
                 opMULDIV: begin
                     if (isa.m) begin
                         // Processor includes "M" extension

--- a/src_Core/RISCY_OOO/procs/lib/Exec.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Exec.bsv
@@ -299,6 +299,10 @@ function CapPipe capModify(CapPipe a, CapPipe b, CapModifyFunc func);
                 setPerms(a_mut, pack(getPerms(a)) & truncate(getAddr(b)));
             tagged SetFlags               :
                 setIntMode(a_mut, getAddr(b)[0]!=0); // XXX Sense swapped for legacy SetFlags
+            tagged CZeroEqz               :
+                ((getAddr(b) == 0) ? nullCap : a);
+            tagged CZeroNez               :
+                ((getAddr(b) != 0) ? nullCap : a);
 `ifdef CHERI_ISAV9
             tagged ClearTag               :
                 setValidCap(a, False);
@@ -314,18 +318,7 @@ function CapPipe capModify(CapPipe a, CapPipe b, CapModifyFunc func);
             tagged FromPtr                :
                 (getAddr(a) == 0 ? nullCap : setAddr(b_mut, getAddr(a)).value);
 `endif
-            tagged SetHigh:
-                fromMem(tuple2(False, {getAddr(b), getAddr(a)}));
-            tagged BuildCap               :
-                setKind(setValidCap(a_mut, !buildCapIllegal), getKind(a)==SENTRY ? SENTRY : UNSEALED);
-            tagged Move                   :
-                a;
-            tagged CZeroEqz               :
-                ((getAddr(b) == 0) ? nullCap : a);
-            tagged CZeroNez               :
-                ((getAddr(b) != 0) ? nullCap : a);
-            tagged ClearTag               :
-                setValidCap(a, False);
+`endif
             default: ?;
         endcase);
     return res;

--- a/src_Core/RISCY_OOO/procs/lib/Exec.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Exec.bsv
@@ -201,6 +201,8 @@ function Data alu(Data a, Data b, AluFunc func);
             Csrw    : b;
             Csrs    : (a | b); // same as Or
             Csrc    : (a & ~b);
+            Eqz     : ((b == 0) ? 0 : a);
+            Nez     : ((b != 0) ? 0 : a);
             default : 0;
         endcase);
     return res;
@@ -312,7 +314,18 @@ function CapPipe capModify(CapPipe a, CapPipe b, CapModifyFunc func);
             tagged FromPtr                :
                 (getAddr(a) == 0 ? nullCap : setAddr(b_mut, getAddr(a)).value);
 `endif
-`endif
+            tagged SetHigh:
+                fromMem(tuple2(False, {getAddr(b), getAddr(a)}));
+            tagged BuildCap               :
+                setKind(setValidCap(a_mut, !buildCapIllegal), getKind(a)==SENTRY ? SENTRY : UNSEALED);
+            tagged Move                   :
+                a;
+            tagged CZeroEqz               :
+                ((getAddr(b) == 0) ? nullCap : a);
+            tagged CZeroNez               :
+                ((getAddr(b) != 0) ? nullCap : a);
+            tagged ClearTag               :
+                setValidCap(a, False);
             default: ?;
         endcase);
     return res;

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -302,7 +302,8 @@ typedef enum {
     Add, Addw, Sub, Subw,
     And, Or, Xor,
     Slt, Sltu, Sll, Sllw, Sra, Sraw, Srl, Srlw,
-    Csrw, Csrs, Csrc
+    Csrw, Csrs, Csrc,
+    Eqz, Nez
 } AluFunc deriving(Bits, Eq, FShow);
 
 typedef enum {
@@ -357,6 +358,8 @@ typedef union tagged {
     void ClearTag;
     void FromPtr;
 `endif
+    void CZeroEqz;
+    void CZeroNez;
 } CapModifyFunc deriving(Bits, Eq, FShow);
 
 typedef union tagged {
@@ -815,6 +818,7 @@ Bit#(3) fnAND   = 3'b111;
 Bit#(7) opALU1   = 7'b0000000;
 Bit#(7) opALU2   = 7'b0100000;
 Bit#(7) opMULDIV = 7'b0000001;
+Bit#(7) opCZERO  = 7'b0000111;
 
 Bit#(3) fnMUL    = 3'b000;
 Bit#(3) fnMULH   = 3'b001;
@@ -824,6 +828,9 @@ Bit#(3) fnDIV    = 3'b100;
 Bit#(3) fnDIVU   = 3'b101;
 Bit#(3) fnREM    = 3'b110;
 Bit#(3) fnREMU   = 3'b111;
+
+Bit#(3) fnEQZ    = 3'b101;
+Bit#(3) fnNEZ    = 3'b111;
 
 // Branch
 Bit#(3) fnBEQ   = 3'b000;

--- a/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/ProcTypes.bsv
@@ -818,7 +818,6 @@ Bit#(3) fnAND   = 3'b111;
 Bit#(7) opALU1   = 7'b0000000;
 Bit#(7) opALU2   = 7'b0100000;
 Bit#(7) opMULDIV = 7'b0000001;
-Bit#(7) opCZERO  = 7'b0000111;
 
 Bit#(3) fnMUL    = 3'b000;
 Bit#(3) fnMULH   = 3'b001;
@@ -909,11 +908,11 @@ Bit#(3) opSCBNDS    = 3'b000;
 Bit#(3) opSCBNDSR   = 3'b001;
 Bit#(3) fnCADDI     = 3'b010;
 
-Bit#(7) opCapInspect = 7'b0001000;
-Bit#(7) opCapArith   = 7'b0000110;
-Bit#(7) opCapBounds  = 7'b0000111;
-Bit#(7) opMSWCap     = 7'b0001001;
-Bit#(7) opMSWInt     = 7'b0001010;
+Bit#(7) opCapInspect     = 7'b0001000;
+Bit#(7) opCapArith       = 7'b0000110;
+Bit#(7) opCapBoundsZero  = 7'b0000111;
+Bit#(7) opMSWCap         = 7'b0001001;
+Bit#(7) opMSWInt         = 7'b0001010;
 
 //MiscMem
 Bit#(3) fnFENCE  = 3'b000;


### PR DESCRIPTION
This implements the `Zicond` extension containing the `czero.eqz` and `czero.nez` instructions.