### PR TITLE
Don't legalise the perms or mode in the fetch stage

### DIFF
--- a/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
+++ b/src_Core/RISCY_OOO/procs/RV64G_OOO/FetchStage.bsv
@@ -184,7 +184,7 @@ typedef struct {
     Bool  cap_mode;
 } PcCompressed deriving(Bits,Eq,FShow);
 function PcCompressed compressPc(PcIdx i, CapMem a) =
-    PcCompressed{idx: i, lsb: truncate(a), cap_mode: !getUnlegalisedIntMode(a)}; // Mode must be legal if we've fetched
+    PcCompressed{idx: i, lsb: truncate(a), cap_mode: !getUnlegalisedIntMode(a)};
 
 typedef struct {
     Addr pc;
@@ -452,7 +452,7 @@ module mkFetchStage(FetchStage);
 
     // PC compression structure holding an indexed set of PC blocks so that only indexes need be tracked.
     IndexedMultiset#(PcIdx, PcMSB, SupSizeX2) pcBlocks <- mkIndexedMultisetQueue;
-    function CapMem decompressPc(PcCompressed p) = setIntMode({pcBlocks.lookup(p.idx),p.lsb}, !p.cap_mode);
+    function CapMem decompressPc(PcCompressed p) = setUnlegalisedIntMode({pcBlocks.lookup(p.idx),p.lsb}, !p.cap_mode);
     // Epochs
     Ehr#(2, Bool) decode_epoch <- mkEhr(False);
     // fetch estimate of main epoch
@@ -816,7 +816,7 @@ module mkFetchStage(FetchStage);
    Vector#(SupSize, DecodeResult) decodeResults = ?;
    for (Integer i = 0; i < valueOf(SupSize); i = i + 1) begin
       CapMem pc = decompressPc(validValue(decodeIn[i]).pc);
-      decodeResults[i] = decode(validValue(decodeIn[i]).inst, !getUnlegalisedIntMode(pc)); // Decode 32b inst, or 32b expansion of 16b inst. Mode must be legal if we've fetched
+      decodeResults[i] = decode(validValue(decodeIn[i]).inst, !getUnlegalisedIntMode(pc)); // Decode 32b inst, or 32b expansion of 16b inst.
       if (popInst(decodeResults[i])) anyReturns = True;
    end
 
@@ -970,7 +970,7 @@ module mkFetchStage(FetchStage);
                   trainInfo.ras <- ras.ras[i].pop(doPop);
                   if (nextPc matches tagged Valid ._nextPc) begin
                      // Override cap mode prediction
-                     nextPc = Valid (setIntMode(_nextPc, getUnlegalisedIntMode(ppc))); // Mode must be legal if we've fetched
+                     nextPc = Valid (setUnlegalisedIntMode(_nextPc, getUnlegalisedIntMode(ppc)));
                   end
                   if(verbose) begin
                      $display("Branch prediction: ", fshow(dInst.iType), " ; ", fshow(pc), " ; ",
@@ -1056,7 +1056,7 @@ module mkFetchStage(FetchStage);
       // update PC and epoch
       if(redirectPc matches tagged Valid .rp) begin
          pc_reg[pc_decode_port] <= rp;
-         cap_mode_reg[cap_mode_decode_port] <= !getUnlegalisedIntMode(rp); // Mode must be legal if we've fetched
+         cap_mode_reg[cap_mode_decode_port] <= !getUnlegalisedIntMode(rp);
          decode_redirect_count <= decode_redirect_count + 1;
       end else begin
          // Update cap_mode based on last decoded frag
@@ -1131,7 +1131,7 @@ module mkFetchStage(FetchStage);
 `endif
     );
         pc_reg[0] <= start_pc;
-        cap_mode_reg[0] <= !getUnlegalisedIntMode(start_pc); // Mode must be legal if we've fetched
+        cap_mode_reg[0] <= !getUnlegalisedIntMode(start_pc);
 `ifdef RVFI_DII
         dii_pid_reg[0] <= dii_pid;
 `endif
@@ -1157,7 +1157,7 @@ module mkFetchStage(FetchStage);
         if (verbose)
         $display("Redirect: newpc %h, old f_main_epoch %d, new f_main_epoch %d, specBits %x",new_pc,f_main_epoch,f_main_epoch+1, specBits);
         pc_reg[pc_redirect_port] <= new_pc;
-        cap_mode_reg[cap_mode_redirect_port] <= !getUnlegalisedIntMode(new_pc); // Mode must be legal if we've fetched
+        cap_mode_reg[cap_mode_redirect_port] <= !getUnlegalisedIntMode(new_pc);
 `ifdef RVFI_DII
         dii_pid_reg[pc_redirect_port] <= dii_pid;
         if (verbose) $display("%t Redirect: dii_pid_reg %d", $time(), dii_pid);


### PR DESCRIPTION
This was causing an assertion failure as non-control flow instructions would change the PC in speculation when they legalised the mode bit. Removed the comments as they're technically not true. Justification that using the unlegalised version is okay would be more like "If we will commit, then the PC must be legal"