### PR TITLE
Fix and check prefetcher HPM counters

### DIFF
--- a/src_Core/CPU/Core.bsv
+++ b/src_Core/CPU/Core.bsv
@@ -1206,23 +1206,27 @@ module mkCore#(CoreId coreId)(Core);
      EventsCore core_evts = unpack(pack(coreFix.memExeIfc.events) | pack(hpm_core_events[0]));
      EventsL1I imem_evts = unpack(pack(iMem.events) | pack(iTlb.events));
      EventsL1D dmem_evts = unpack(pack(dMem.events) | pack(dTlb.events));
-     EventsTGC tgc_evts = events_tgc_reg;
+     //EventsTGC tgc_evts = events_tgc_reg;
      EventsLL llmem_evts = unpack(pack(events_llc_reg) | pack(l2Tlb.events));
 
-     core_evts.evt_TRAP = dmem_evts.evt_AMO;
-     core_evts.evt_JAL = dmem_evts.evt_AMO_MISS;
-     core_evts.evt_JALR = dmem_evts.evt_AMO_MISS_LAT;
+     EventsTGC tgc_evts = unpack(0);   
+     
+     core_evts.evt_JALR = dmem_evts.evt_AMO_MISS_LAT;  // total l1  <- 5
+     core_evts.evt_JAL = dmem_evts.evt_AMO_MISS;       // miss L1   <- 6
+     core_evts.evt_TRAP = dmem_evts.evt_AMO;           // useful L1 <- 7
+     tgc_evts.evt_READ = dmem_evts.evt_EVICT;          // late L1   <- 25
 
-     core_evts.evt_REDIRECT = llmem_evts.evt_EVICT;
-     tgc_evts.evt_EVICT = llmem_evts.evt_TLB_FLUSH;
-     tgc_evts.evt_WRITE = llmem_evts.evt_ST;
-     tgc_evts.evt_SET_TAG_WRITE = llmem_evts.evt_ST;
 
-     core_evts.evt_BRANCH = (rob.isFull_ehrPort0) ? 1 : 0;
+     tgc_evts.evt_READ_MISS = llmem_evts.evt_ST;          // total LL  <- 26
+     // llmem_evts.evt_EVICT;                             // missed LL <- already event 27
+     tgc_evts.evt_WRITE_MISS = llmem_evts.evt_TLB_FLUSH;  // useful LL <- 28
+     tgc_evts.evt_EVICT = llmem_evts.evt_ST_MISS;         // late LL   <- 29
 
-     tgc_evts.evt_READ = events_llc_reg.evt_TLB;
-     tgc_evts.evt_SET_TAG_READ = events_llc_reg.evt_TLB;
-     tgc_evts.evt_READ_MISS = events_llc_reg.evt_TLB_MISS;
+     //core_evts.evt_BRANCH = (rob.isFull_ehrPort0) ? 1 : 0;
+
+     //tgc_evts.evt_READ = events_llc_reg.evt_TLB;
+     //tgc_evts.evt_SET_TAG_READ = events_llc_reg.evt_TLB;
+     //tgc_evts.evt_READ_MISS = events_llc_reg.evt_TLB_MISS;
 
 
         /*

--- a/src_Core/Core/CoreW.bsv
+++ b/src_Core/Core/CoreW.bsv
@@ -251,8 +251,8 @@ module mkCoreW_reset #(Reset porReset)
       //evts.evt_READ_MISS = zeroExtend(pack(cache_core_evts.evt_READ_MISS));
       //evts.evt_EVICT = zeroExtend(pack(cache_core_evts.evt_EVICT));
 `ifdef USECAP
-      evts.evt_SET_TAG_WRITE = zeroExtend(pack(cache_core_evts.evt_SET_TAG_WRITE));
-      evts.evt_SET_TAG_READ = zeroExtend(pack(cache_core_evts.evt_SET_TAG_READ));
+      //evts.evt_SET_TAG_WRITE = zeroExtend(pack(cache_core_evts.evt_SET_TAG_WRITE));
+      //evts.evt_SET_TAG_READ = zeroExtend(pack(cache_core_evts.evt_SET_TAG_READ));
 `endif
       proc.events_tgc(evts);
    endrule

--- a/src_Core/RISCY_OOO/coherence/src/L1Bank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/L1Bank.bsv
@@ -250,7 +250,7 @@ module mkL1Bank#(
     Count#(Data) amoMissLat <- mkCount(0);
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsL1D)) perf_events <- mkDRegOR (5, unpack (0));
+    Array #(Reg #(EventsL1D)) perf_events <- mkDRegOR (6, unpack (0));
 `endif
 function Action incrReqCnt(MemOp op, Addr boundsOffset, Addr boundsLength);
 action
@@ -528,7 +528,7 @@ endfunction
                     fshow(r.op)
                 );
             EventsL1D events = unpack (0);
-            events.evt_AMO_MISS_LAT = 1;
+            events.evt_AMO_MISS = 1;
             perf_events[2] <= events;
         end        
     endrule
@@ -1087,6 +1087,12 @@ endfunction
                     // If this is a prefetch, we can drop the prefetch here (prefetch was probably late)
                     if (cRqIsPrefetch[n]) begin
                         cRqDrop;
+                        // This prefetch was late
+                        if (!cRqIsPrefetch[cOwner]) begin
+                            EventsL1D events = unpack (0);
+                            events.evt_EVICT = 1;
+                            perf_events[5] <= events;
+                        end
                     end else begin
                         cRqSetDepNoCacheChange;
                     end
@@ -1220,7 +1226,7 @@ endfunction
             end
             else begin
                 EventsL1D events = unpack (0);
-                events.evt_AMO_MISS = 1;
+                events.evt_AMO_MISS_LAT = 1;
                 perf_events[3] <= events;
             end
         end

--- a/src_Core/RISCY_OOO/coherence/src/LLBank.bsv
+++ b/src_Core/RISCY_OOO/coherence/src/LLBank.bsv
@@ -323,7 +323,7 @@ module mkLLBank#(
     Count#(Data) dmaStReqCnt <- mkCount(0);
 `endif
 `ifdef PERFORMANCE_MONITORING
-    Array #(Reg #(EventsLL)) perf_events <- mkDRegOR (6, unpack (0));
+    Array #(Reg #(EventsLL)) perf_events <- mkDRegOR (9, unpack (0));
 `endif
 
     function Action incrMissCnt(cRqT cRq, cRqIndexT idx, Bool isDma, Bool isInstructionAccess);
@@ -969,7 +969,7 @@ module mkLLBank#(
                 doLdAfterReplace <= True;
 `ifdef PERFORMANCE_MONITORING
                 EventsLL events = unpack (0);
-                events.evt_ST_MISS = 1;
+                //events.evt_ST_MISS = 1;
                 perf_events[0] <= events;
 `endif
                if (verbose)
@@ -1628,6 +1628,12 @@ module mkLLBank#(
                     // add to same addr dependency
                     if (cRqIsPrefetch[n]) begin
                         cRqDrop;
+                        // This prefetch was late
+                        if (!cRqIsPrefetch[m]) begin
+                            EventsLL events = unpack (0);
+                            events.evt_ST_MISS = 1;
+                            perf_events[7] <= events;
+                        end
                     end else begin
                         cRqMshr.pipelineResp.setAddrSucc(m, Valid (n));
                         cRqSetDepNoCacheChange;
@@ -1636,6 +1642,16 @@ module mkLLBank#(
                     $display("%t LL %m pipelineResp: cRq: own by other cRq, same addr dep: ", $time,
                         fshow(cOwner), " ; ", fshow(cRqEOC)
                     );
+                    if (prefetchVerbose)
+                        $display("%t LL cRq dependency (addr succ): mshr: %d, depMshr: %d, addr: 0x%h, cRq is prefetch: %d, other is prefetch: %d, reqCs: ",
+                            cur_cycle,
+                            n,
+                            m,
+                            cRq.addr,
+                            cRqIsPrefetch[n],
+                            cRqIsPrefetch[m],
+                            fshow(cRq.toState)
+                        );
                 end
                 else begin
                     // must be hitting on a line being replaced
@@ -1651,16 +1667,17 @@ module mkLLBank#(
                         fshow(cOwner)
                     );
                     doAssert(cOwner.replacing, "line must be replacing");
+                    if (prefetchVerbose)
+                        $display("%t LL cRq dependency (rep succ): mshr: %d, depMshr: %d, addr: 0x%h, cRq is prefetch: %d, other is prefetch: %d, reqCs: ",
+                            cur_cycle,
+                            n,
+                            cOwner.mshrIdx,
+                            cRq.addr,
+                            cRqIsPrefetch[n],
+                            cRqIsPrefetch[cOwner.mshrIdx],
+                            fshow(cRq.toState)
+                        );
                 end
-                if (prefetchVerbose)
-                    $display("%t LL cRq dependency: mshr: %d, depMshr: %d, addr: 0x%h, cRq is prefetch: %d, reqCs: ",
-                        cur_cycle,
-                        n,
-                        cOwner,
-                        cRq.addr,
-                        cRqIsPrefetch[n],
-                        fshow(cRq.toState)
-                    );
             end
             else begin
                 // owner is myself, so must be swapped in
@@ -1721,17 +1738,23 @@ module mkLLBank#(
                 );
                 if (cRqIsPrefetch[n]) begin
                     cRqDrop;
+                    if (!cRqIsPrefetch[m]) begin
+                        EventsLL events = unpack (0);
+                        events.evt_ST_MISS = 1;
+                        perf_events[8] <= events;
+                    end
                 end else begin
                     cRqMshr.pipelineResp.setAddrSucc(m, Valid (n));
                     cRqSetDepNoCacheChange;
                 end
                 if (prefetchVerbose)
-                    $display("%t LL cRq dependency: mshr: %d, depMshr: %d, addr: 0x%h, cRq is prefetch: %d, reqCs: ",
+                    $display("%t LL cRq dependency (addr succ): mshr: %d, depMshr: %d, addr: 0x%h, cRq is prefetch: %d, other is prefetch: %d, reqCs: ",
                         cur_cycle,
                         n,
                         m,
                         cRq.addr,
                         cRqIsPrefetch[n],
+                        cRqIsPrefetch[m],
                         fshow(cRq.toState)
                     );
             end


### PR DESCRIPTION
Now, the following counter mappings are overridden:

### L1D cache prefetch events:

**JALR** - no. of prefetches issued into the L1D cache
**JAL** - no. of prefetches issued into the L1D cache that missed
**TRAP** - no. of prefetches issued into the L1D cache that missed (thus triggering a refill) and were subsequently demanded by the core (i.e. the no. of useful prefetches)
**Tag Cache Load** - no. of prefetches issued into the L1D cache after a demand request was issued for the same address (i.e. the no. of late prefetches)

### LL cache prefetch events:

**Tag Cache Load Miss** - no. of prefetches issued *directly* into the LL cache 
**LL Cache Evict (aka tag cache store)** - no. of prefetches issued *directly* into the LL cache that missed
**Tag Cache Store Miss** - no. of prefetches issued *directly* into the LL cache that missed (thus triggering a refill) and were subsequently demanded by the core (i.e. the no. of useful prefetches)
**Tag Cache Evict** - no. of prefetches issued *directly* into the LL cache after a demand request was issued for the same address (i.e. the no. of late prefetches)


