### PR TITLE
Added correction for sfence decoding

### DIFF
--- a/src_Core/RISCY_OOO/procs/lib/Decode.bsv
+++ b/src_Core/RISCY_OOO/procs/lib/Decode.bsv
@@ -964,10 +964,12 @@ function DecodeResult decode(Instruction inst, Bool cap_mode);
         opcSystem: begin
             if (funct3 == fnPRIV) begin
                 if (funct7 == privSFENCEVMA) begin
-                    dInst.iType = SFence;
-                    legalInst = True;
-                    // FIXME SFENCE.VMA is implemented in coarse grain,
-                    // ignoring rs1 and rs2
+                    if(rd == 0) begin
+                        dInst.iType = SFence;
+                        legalInst = True;
+                        // FIXME SFENCE.VMA is implemented in coarse grain,
+                        // ignoring rs1 and rs2
+                    end
                 end
                 else begin
                     Maybe#(IType) mIType = case (truncate(immI))


### PR DESCRIPTION
`rd` needs to be all zeros.