### PR TITLE
Cheri benchmarks - update Run_benchmarks.py

### DIFF
--- a/Tests/Run_benchmarks.py
+++ b/Tests/Run_benchmarks.py
@@ -9,19 +9,8 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 parser = ArgumentParser(\
     prog = "Run_benchmarks.py", \
-    description = """Runs a RISC-V simulation executable on Benchmark tests: 
-ELF files taken from <repo-dir>/Tests/benchmarks and its sub-directories.
-
-Example:
-      `$ <this_prog>  .exe_HW_sim  ~somebody/GitHub/Toooba ./Logs -v -p 4`
-    will run the verilator simulation executable on the following RISC-V ISA tests:
-            ~somebody/GitHub/Toooba/Tests/benchmarks/*.bin
-    and will leave a transcript of each test's simulation output in files like
-            ./Logs/rv32ui-p-add.log
-    Each log will contain an instruction trace (because of the '-v' arg).
-    It will use 4 processes in parallel to run the regressions.
-    (creating temporary working directories worker_0, ..., worker_3)""", \
-    epilog = "For more details, see $(REPO)/Tests/Run_benchmarks.py", \
+    description = "Runs a RISC-V simulation executable on Benchmark tests - ELF files taken from <repo>/Tests/benchmarks and its sub-directories.", \
+    epilog = """For Example: `$ <this_prog>  .exe_HW_sim  ~somebody/GitHub/Toooba ./Logs -v -p 4` will run the verilator simulation executable on the following RISC-V ISA tests: `~somebody/GitHub/Toooba/Tests/benchmarks/*.bin` and will leave a transcript of each test's simulation output in files like `./Logs/rv32ui-p-add.log`. Each log will contain an instruction trace (because of the '-v' arg). It will use 4 processes in parallel to run the regressions.(creating temporary working directories worker_0, ..., worker_3). \n\nFor more details, see $(REPO)/Tests/Run_benchmarks.py""", \
     add_help = True, \
     formatter_class=RawDescriptionHelpFormatter
 )
@@ -29,9 +18,12 @@ Example:
 parser.add_argument("sim_path", type=str, help="Run this simulation executable on the Benchmark tests - Required")
 parser.add_argument("repo", type=str, help="Root Directory of the Toooba Repository - used to locate the Benchmarks - Required")
 parser.add_argument("logs_path", type=str, help="For each ELF file FOO, saves simulation output in `<logs_path>/FOO.log` - Required")
+parser.add_argument("csvFile", type=str, help="Write CSV of performance results to this file")
 parser.add_argument("--verbose", "-v", action="count", default=0, help="Print additional information during simulation: `-v` = instruction trace; `-vv` = pipeline stage state")
 parser.add_argument("--parallelism", "-p", type=int, default=multiprocessing.cpu_count ()-4 ,help="Specifies the number of parallel processes used (creates temporary separate working directories worker_0, worker_1, ...). By default uses the number of CPUs listed in `/proc/cpuinfo - 4`.")
 parser.add_argument("--timeout_secs", type=int, default=6000, help="Specifies the number of seconds to wait for each command run. Defaults to 6000s")
+# Log files currently take up ~25GB per run, use this flag to minimise logfile storage
+parser.add_argument("--no_write_logs", action="store_false", help="Don't write success logfiles to reduce storage overhead of run - requires Python >= 3.6")
 
 args = parser.parse_args()
 
@@ -39,7 +31,7 @@ import sys
 import os
 import stat
 import subprocess
-
+import re
 
 # ================================================================
 # DEBUGGING ONLY: This exclude list allows skipping some specific test
@@ -90,6 +82,15 @@ def main (argv = None):
     global timeout
     sys.stdout.write (f"Using {timeout}s timeout\n")
 
+    csvFile = os.path.abspath(os.path.normpath(args.csvFile))
+    if not (os.path.exists(csvFile) and os.path.isfile(csvFile)):
+        print (f"Creating performance output CSV {csvFile}")
+        (dir, f) = os.path.split(csvFile)
+        os.makedirs(dir, exist_ok=True)
+        with open(csvFile, "x") as f: # `touch csvFile`
+            pass
+    
+
     # End of command-line arg processing
     # ================================================================
 
@@ -138,10 +139,15 @@ def main (argv = None):
 
     # Create a shared array for each worker's (n_executed, n_passed) results
     results = multiprocessing.Array ('L', [ 0 for j in range (2 * n_workers) ])
+    man = multiprocessing.Manager()
+    csvQ = man.Queue()
     args_dict ['results'] = results
 
+    args_dict['write_logs'] = args.no_write_logs
+    args_dict['csvQ'] = csvQ
+
     # Create a TAP file to output individual test results in TAP format
-    tap_out = open("../isa_test_report.tap", "w")
+    tap_out = open("./benchmark_report.tap", "w")
     tap_out.write("1.." + str(n_tests) + "\n")
     tap_out.close()
 
@@ -175,6 +181,16 @@ def main (argv = None):
     sys.stdout.write ("Executed:    {0} tests\n".format (num_executed))
     sys.stdout.write ("PASS:        {0} tests\n".format (num_passed))
     sys.stdout.write ("FAIL:        {0} tests\n".format (num_executed - num_passed))
+
+    # Write the Performance CSV - replaces `report_log.sh`
+    csvLines = []
+    while not(csvQ.empty()):
+        csvLines.append(csvQ.get())
+    csvLines.sort()
+    with open(csvFile, "w") as f:
+        f.write("Log, Cycles, Instructions\n")
+        f.write("".join(csvLines))
+
     return 0
 
 # ================================================================
@@ -217,6 +233,7 @@ def do_worker (worker_num, args_dict):
     filenames = args_dict ['filenames']
     index     = args_dict ['index']
     results   = args_dict ['results']
+    csvQ = args_dict ['csvQ']
 
     num_executed = 0
     num_passed   = 0
@@ -234,7 +251,7 @@ def do_worker (worker_num, args_dict):
             return
         filename = filenames [my_index]
 
-        (message, passed) = do_benchmark (args_dict, filename)
+        (message, passed, csvline) = do_benchmark (args_dict, filename)
         num_executed = num_executed + 1
 
         if passed:
@@ -252,6 +269,7 @@ def do_worker (worker_num, args_dict):
                                       num_passed,
                                       num_executed - num_passed))
         sys.stdout.write (message)
+        csvQ.put(csvline)
         # Create a TAP file to output individual test result in TAP format
         tap_out = open("../benchmark_report.tap", "a+")
         tap_out.write(("ok" if passed else "not ok") + " " + str(my_index + 1) + " - " + filenames[my_index] + "\n")
@@ -286,16 +304,23 @@ def do_benchmark (args_dict, full_filename):
     log_filename = os.path.join (args_dict ['logs_path'], basename + ".log")
     message = message + ("    Writing log: {0}\n".format (log_filename))
 
+    csvline = ""
+
     with open (log_filename, 'w') as fd:
-        completed_process1 = run_command (command1, fd)
+        completed_process1 = run_command (command1, fd, args_dict["write_logs"])
         
         if completed_process1 is not None and completed_process1.returncode == 0:
-            completed_process2 = run_command (command2, fd)
+            completed_process2 = run_command (command2, fd, args_dict["write_logs"])
             passed = completed_process2 is not None and \
                 completed_process2.returncode == 0 and \
                 not completed_process2.stdout.endswith ("FAIL 1")
         else:
             passed = False
+
+        if passed:
+            out = list(completed_process2.stdout.split("\n")[-1000:].__reversed__()) # Truncate and `tac`
+            instretLine = list(filter((lambda s: "instret" in s), out))[0] # `grep -m 1`
+            csvline = f"{basename}.log, {re.sub(r"^instret:(\d+).*? (\d+)$", r"\2, \1", instretLine)}\n" # `sed ...`
 
     # If Tandem Verification trace file was created, save it as well
     if os.path.exists ("./trace_out.dat"):
@@ -303,13 +328,13 @@ def do_benchmark (args_dict, full_filename):
         os.rename ("./trace_out.dat", trace_filename)
         message = message + ("    Trace output saved in: {0}\n".format (trace_filename))
 
-    return (message, passed)
+    return (message, passed, csvline)
 
 # ================================================================
 # This is a wrapper around 'subprocess.run' because of an annoying
 # incompatible change in moving from Python 3.5 to 3.6
 
-def run_command (command, log_fd):
+def run_command (command, log_fd, write_log=True):
     command_str = " ".join(command)
     log_fd.write (f"Running: {command_str}\n")
     try:
@@ -330,9 +355,10 @@ def run_command (command, log_fd):
                                     stderr = subprocess.STDOUT,
                                     encoding='utf-8',
                                     timeout=timeout)
-        log_fd.write(f"Finished with exit code {result.returncode}\n")
-        log_fd.write("Stdout:\n")
-        log_fd.write (result.stdout)
+        if write_log or result.returncode != 0:
+            log_fd.write(f"Finished with exit code {result.returncode}\n")
+            log_fd.write("Stdout:\n")
+            log_fd.write (result.stdout)
         return result
     except subprocess.TimeoutExpired:
         sys.stderr.write(f"TIMEOUT: {command_str} !\n")

--- a/Tests/Run_benchmarks.py
+++ b/Tests/Run_benchmarks.py
@@ -20,7 +20,6 @@ usage_line = (
     "      Specifies the number of parallel processes used\n"
     "        (creates temporary separate working directories worker_0, worker_1, ...)\n"
     "      By default uses the number of CPUs listed in /proc/cpuinfo - 4.\n"
-    "      In any case, limits it to 8.\n"
     "\n"
     " If <opt timeout_secs> is given, it must be an integer and must follow an explicit <opt parallelism>\n"
     "      Specifies the number of seconds to wait for each command run.\n"
@@ -48,8 +47,6 @@ import multiprocessing
 # DEBUGGING ONLY: This exclude list allows skipping some specific test
 
 exclude_list = []
-
-n_workers_max = 8
 
 timeout = 6000
 
@@ -117,7 +114,7 @@ def main (argv = None):
         j = 6
     else:
         n_workers = multiprocessing.cpu_count () - 4
-    n_workers = max(min (n_workers_max, n_workers), 1)
+    n_workers = max(n_workers, 1)
     sys.stdout.write ("Using {0} worker processes\n".format (n_workers))
 
     global timeout
@@ -170,6 +167,8 @@ def main (argv = None):
         return 0
     args_dict ['filenames'] = filenames
     args_dict ['n_tests']   = n_tests
+
+    n_workers = min(n_tests, n_workers)
 
     # Create a shared counter to index into the list of filenames
     index = multiprocessing.Value ('L', 0)    # Unsigned long (4 bytes)

--- a/Tests/Run_benchmarks.py
+++ b/Tests/Run_benchmarks.py
@@ -3,124 +3,91 @@
 # Copyright (c) 2018-2019 Bluespec, Inc.
 # See LICENSE for license details
 
-usage_line = (
-    "  Usage:\n"
-    "    $ <this_prog>    <simulation_executable>  <repo_dir>  <logs_dir> <opt verbosity>  <opt parallelism> <opt timeout_secs>\n"
-    "\n"
-    "  Runs the RISC-V <simulation_executable>\n"
-    "  on ISA tests: ELF files taken from <repo-dir>/isa and its sub-directories.\n"
-    "\n"
-    "  For each ELF file FOO, saves simulation output in <logs_dir>/FOO.log. \n"
-    "\n"
-    "  If <opt verbosity> is given, it must be one of the following:\n"
-    "      v1:    Print instruction trace during simulation\n"
-    "      v2:    Print pipeline stage state during simulation\n"
-    "\n"
-    "  If <opt parallelism> is given, it must be an integer\n"
-    "      Specifies the number of parallel processes used\n"
-    "        (creates temporary separate working directories worker_0, worker_1, ...)\n"
-    "      By default uses the number of CPUs listed in /proc/cpuinfo - 4.\n"
-    "\n"
-    " If <opt timeout_secs> is given, it must be an integer and must follow an explicit <opt parallelism>\n"
-    "      Specifies the number of seconds to wait for each command run.\n"
-    "      Defaults to 60s\n."
-    "\n"
-    "  Example:\n"
-    "      $ <this_prog>  .exe_HW_sim  ~somebody/GitHub/Toooba ./Logs v1 4\n"
-    "    will run the verilator simulation executable on the following RISC-V ISA tests:\n"
-    "            ~somebody/GitHub/Tests/benchmarks/*.bin\n"
-    "    and will leave a transcript of each test's simulation output in files like\n"
-    "            ./Logs/rv32ui-p-add.log\n"
-    "    Each log will contain an instruction trace (because of the 'v1' arg).\n"
-    "    It will use 4 processes in parallel to run the regressions.\n"
-    "        (creating temporary working directories worker_0, ..., worker_4)\n"
+from os import PathLike
+import multiprocessing
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+
+parser = ArgumentParser(\
+    prog = "Run_benchmarks.py", \
+    description = """Runs a RISC-V simulation executable on Benchmark tests: 
+ELF files taken from <repo-dir>/Tests/benchmarks and its sub-directories.
+
+Example:
+      `$ <this_prog>  .exe_HW_sim  ~somebody/GitHub/Toooba ./Logs -v -p 4`
+    will run the verilator simulation executable on the following RISC-V ISA tests:
+            ~somebody/GitHub/Toooba/Tests/benchmarks/*.bin
+    and will leave a transcript of each test's simulation output in files like
+            ./Logs/rv32ui-p-add.log
+    Each log will contain an instruction trace (because of the '-v' arg).
+    It will use 4 processes in parallel to run the regressions.
+    (creating temporary working directories worker_0, ..., worker_3)""", \
+    epilog = "For more details, see $(REPO)/Tests/Run_benchmarks.py", \
+    add_help = True, \
+    formatter_class=RawDescriptionHelpFormatter
 )
+
+parser.add_argument("sim_path", type=str, help="Run this simulation executable on the Benchmark tests - Required")
+parser.add_argument("repo", type=str, help="Root Directory of the Toooba Repository - used to locate the Benchmarks - Required")
+parser.add_argument("logs_path", type=str, help="For each ELF file FOO, saves simulation output in `<logs_path>/FOO.log` - Required")
+parser.add_argument("--verbose", "-v", action="count", default=0, help="Print additional information during simulation: `-v` = instruction trace; `-vv` = pipeline stage state")
+parser.add_argument("--parallelism", "-p", type=int, default=multiprocessing.cpu_count ()-4 ,help="Specifies the number of parallel processes used (creates temporary separate working directories worker_0, worker_1, ...). By default uses the number of CPUs listed in `/proc/cpuinfo - 4`.")
+parser.add_argument("--timeout_secs", type=int, default=6000, help="Specifies the number of seconds to wait for each command run. Defaults to 6000s")
+
+args = parser.parse_args()
 
 import sys
 import os
 import stat
 import subprocess
 
-import multiprocessing
 
 # ================================================================
 # DEBUGGING ONLY: This exclude list allows skipping some specific test
 
 exclude_list = []
 
-timeout = 6000
+def error(line:str):
+    sys.stderr.write(line)
+    parser.print_usage(file=sys.stderr)
+    sys.exit(1)
 
-def print_hello ():
-    print ("hello")
 # ================================================================
 
+timeout = args.timeout_secs
+
 def main (argv = None):
-    print ("Use flag --help  or --h for a help message")
-    if ((len (argv) <= 1) or
-        (argv [1] == '-h') or (argv [1] == '--help') or
-        (len (argv) < 4)):
-
-        sys.stdout.write (usage_line)
-        sys.stdout.write ("\n")
-        return 0
-
+    args_dict = {}
     # Simulation executable
-    if not (os.path.exists (argv [1])):
-        sys.stderr.write ("ERROR: The given simulation path does not seem to exist?\n")
-        sys.stderr.write ("    Simulation path: " + sim_path + "\n")
-        sys.exit (1)
-    args_dict = {'sim_path': os.path.abspath (os.path.normpath (argv [1]))}
+    sim_path = args.sim_path
+    if not (os.path.exists (sim_path)):
+        error(f"ERROR: The given simulation path does not seem to exist?\n    Simulation path: {sim_path}\n")
+    args_dict['sim_path'] = os.path.abspath (os.path.normpath (sim_path))
 
     # Repo in which to find ELFs and elf_to_hex executable
-    if (not os.path.exists (argv [2])):
-        sys.stderr.write ("ERROR: repo directory ({0}) does not exist?\n".format (argv [2]))
-        sys.stdout.write ("\n")
-        sys.stdout.write (usage_line)
-        sys.stdout.write ("\n")
-        return 1
-    repo = os.path.abspath (os.path.normpath (argv [2]))
-
+    repo = os.path.abspath (os.path.normpath (args.repo))
+    if (not os.path.exists (repo)):
+        error(f"ERROR: repo directory ({repo}) does not exist?\n")
+    
     elfs_path = os.path.join (repo, "Tests", "benchmarks")
     if (not os.path.exists (elfs_path)):
-        sys.stderr.write ("ERROR: BINs directory ({0}) does not exist?\n".format (elfs_path))
-        sys.stdout.write ("\n")
-        sys.stdout.write (usage_line)
-        sys.stdout.write ("\n")
-        return 1
+        error(f"ERROR: BINs directory ({elfs_path}) does not exist?\n")
     args_dict ['elfs_path'] = elfs_path
 
     # Logs directory
-    logs_path = os.path.abspath (os.path.normpath (argv [3]))
+    logs_path = os.path.abspath (os.path.normpath (args.logs_path))
     if not (os.path.exists (logs_path) and os.path.isdir (logs_path)):
         print ("Creating dir: " + logs_path)
         os.mkdir (logs_path)
     args_dict ['logs_path'] = logs_path
 
-    # Optional verbosity
-    verbosity = 0
-    j = 4
-    if len (argv) >= 5:
-        if argv [4] == "v1":
-            verbosity = 1
-            j = 5
-        elif argv [4] == "v2":
-            verbosity = 2
-            j = 5
-    args_dict ['verbosity'] = verbosity
 
-    # Optional parallelism; limit it to 8
-    if len (argv [j:]) != 0 and isdecimal (argv [j]):
-        n_workers = int (argv [j])
-        j = 6
-    else:
-        n_workers = multiprocessing.cpu_count () - 4
-    n_workers = max(n_workers, 1)
+    args_dict ['verbosity'] = args.verbose
+
+    # Optional parallelism
+    n_workers = min(max(args.parallelism, 1), multiprocessing.cpu_count())
     sys.stdout.write ("Using {0} worker processes\n".format (n_workers))
 
     global timeout
-    if len(argv[j:]) != 0 and isdecimal (argv[j]):
-        timeout = int(argv[j])
-        j = 7
     sys.stdout.write (f"Using {timeout}s timeout\n")
 
     # End of command-line arg processing
@@ -129,12 +96,7 @@ def main (argv = None):
     # elf_to_hex executable
     elf_to_hex_exe = os.path.join (repo, "Tests", "elf_to_hex", "elf_to_hex")
     if (not os.path.exists (elf_to_hex_exe)):
-        sys.stderr.write ("ERROR: elf_to_hex executable does not exist?\n")
-        sys.stderr.write ("    at {0}\n".format (elf_to_hex_exe))
-        sys.stdout.write ("\n")
-        sys.stdout.write (usage_line)
-        sys.stdout.write ("\n")
-        return 1
+        error(f"ERROR: elf_to_hex executable does not exist?\n    at {elf_to_hex_exe}\n")
     args_dict ['elf_to_hex_exe'] = elf_to_hex_exe
 
     sys.stdout.write ("Parameters:\n")

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -103,7 +103,7 @@ isa_tests:
 .PHONY: benchmarks
 benchmarks:
 	@echo "Running benchmarks; saving logs in Logs/"
-	$(REPO)/Tests/Run_benchmarks.py  ./exe_HW_sim  $(REPO)  ./Logs
+	$(TESTS_DIR)/Run_benchmarks.py $(BENCHMARK_ARGS) ./exe_HW_sim  $(REPO)  ./Logs
 	@echo "Finished running benchmarks"
 	$(REPO)/Tests/benchmarks/report_log.sh Logs/*.bin.log
 

--- a/builds/Resources/Include_Common.mk
+++ b/builds/Resources/Include_Common.mk
@@ -103,9 +103,9 @@ isa_tests:
 .PHONY: benchmarks
 benchmarks:
 	@echo "Running benchmarks; saving logs in Logs/"
-	$(TESTS_DIR)/Run_benchmarks.py $(BENCHMARK_ARGS) ./exe_HW_sim  $(REPO)  ./Logs
+	$(TESTS_DIR)/Run_benchmarks.py $(BENCHMARK_ARGS) ./exe_HW_sim  $(REPO)  ./Logs benchmark_results_$(TIMESTAMP).csv
 	@echo "Finished running benchmarks"
-	$(REPO)/Tests/benchmarks/report_log.sh Logs/*.bin.log
+	@column -s, -t < benchmark_results_$(TIMESTAMP).csv
 
 # ================================================================
 # Generate Bluespec CHERI tag controller source file


### PR DESCRIPTION
Refactored Argument Parsing and added additional options to Run_benchmarks.py
- argument parsing updated to use the `argparse` library, providing much more flexibility in usage.
- Rewrote verbosity, parallelism and timeout options to be independent of each other
- Moved the functionality of `Tests/benchmarks/report_log.sh` into the python script - updated Makefile to match
- Added option to not write passing benchmark logs, to reduce disk usage for scripting
- Removed 8 worker number limit, will now default to \#cores - 4
- Added functionality in makefile to pass extra arguments in by defining `BENCHMARK_ARGS` variable

New usage:
```
Run_benchmarks.py [-h] [--verbose] [--parallelism PARALLELISM] [--timeout_secs TIMEOUT_SECS] [--no_write_logs] sim_path repo logs_path csvFile
```

@jonwoodruff 